### PR TITLE
Extraneous async removal and message loop cleanup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -858,6 +858,7 @@ dependencies = [
  "clap",
  "consensus",
  "eyre 0.6.12",
+ "matching-engine",
  "order-pool",
  "reth",
  "reth-metrics",
@@ -907,6 +908,8 @@ dependencies = [
  "aquamarine",
  "async-trait",
  "auto_impl",
+ "bincode 2.0.0-rc.3",
+ "blsful",
  "enr 0.10.0",
  "fnv",
  "futures",
@@ -961,6 +964,8 @@ dependencies = [
  "angstrom-types",
  "angstrom-utils",
  "async-trait",
+ "bincode 2.0.0-rc.3",
+ "consensus",
  "hyper 1.4.1",
  "jsonrpsee",
  "metrics 0.21.1",
@@ -1005,12 +1010,15 @@ dependencies = [
  "alloy-sol-types",
  "anyhow",
  "base64 0.22.1",
+ "bincode 2.0.0-rc.3",
  "bitmaps",
  "blsful",
  "bytes",
  "derive_more",
  "eyre 0.3.10",
  "hex-literal",
+ "itertools 0.12.1",
+ "malachite",
  "modular-bitfield",
  "open-fastrlp",
  "rand 0.8.5",
@@ -1646,6 +1654,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "bincode"
+version = "2.0.0-rc.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f11ea1a0346b94ef188834a65c068a03aec181c94896d481d7a0a40d85b0ce95"
+dependencies = [
+ "bincode_derive",
+ "serde",
+]
+
+[[package]]
+name = "bincode_derive"
+version = "2.0.0-rc.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e30759b3b99a1b802a7a3aa21c85c3ded5c28e1c83170d82d70f08bbf7f3e4c"
+dependencies = [
+ "virtue",
 ]
 
 [[package]]
@@ -2490,14 +2517,18 @@ dependencies = [
  "eyre 0.6.12",
  "futures",
  "hex-literal",
+ "matching-engine",
  "order-pool",
  "rayon",
  "reth-metrics",
  "reth-primitives",
  "reth-provider",
+ "reth-rpc-types",
  "reth-tasks",
+ "secp256k1 0.29.0",
  "serde",
  "serde_json",
+ "testing-tools",
  "thiserror",
  "tokio",
  "tokio-stream",
@@ -4258,7 +4289,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.4.10",
+ "socket2 0.5.7",
  "tokio",
  "tower-service",
  "tracing",
@@ -5385,10 +5416,14 @@ dependencies = [
  "clap",
  "criterion",
  "divan",
+ "futures-util",
  "malachite",
  "malachite-q",
  "rand 0.8.5",
  "rand_distr",
+ "reth-tasks",
+ "testing-tools",
+ "tokio",
  "uniswap_v3_math",
 ]
 
@@ -7934,7 +7969,7 @@ version = "1.0.0"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.0.0#83d412da70af678a46f368533b6df45a287a1ce6"
 dependencies = [
  "anyhow",
- "bincode",
+ "bincode 1.3.3",
  "cuckoofilter",
  "derive_more",
  "lz4_flex",
@@ -10012,9 +10047,11 @@ dependencies = [
  "eyre 0.6.12",
  "futures",
  "jsonrpsee",
+ "matching-engine",
  "order-pool",
  "parking_lot 0.12.3",
  "rand 0.8.5",
+ "rand_distr",
  "reth-beacon-consensus",
  "reth-blockchain-tree",
  "reth-chainspec",
@@ -10978,6 +11015,12 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "virtue"
+version = "0.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dcc60c0624df774c82a0ef104151231d37da4962957d691c011c852b2473314"
 
 [[package]]
 name = "void"


### PR DESCRIPTION
Fix for some small issues after PR 181, removing extraneous async declarations and moving the ConsensusManager message loop to be associated directly with the struct