### PR TITLE
Fix PADE header vec count bug

### DIFF
--- a/crates/pade-macro/src/encode.rs
+++ b/crates/pade-macro/src/encode.rs
@@ -103,7 +103,9 @@ fn build_struct_impl(name: &Ident, generics: &Generics, s: &DataStruct) -> Token
 
                     headers.force_align();
                     let mut raw = headers.into_vec();
-                    raw[0] >>= 8 - extra;
+                    if let Some(b) = raw.first_mut() {
+                        *b >>= 8 - extra
+                    }
                     raw.extend(base);
 
                     [raw, output].concat()

--- a/crates/pade-macro/tests/test.rs
+++ b/crates/pade-macro/tests/test.rs
@@ -131,3 +131,34 @@ fn can_derive_on_generics() {
         Items { vector: Vec<A> }
     }
 }
+
+#[test]
+fn handles_odd_bool_counts() {
+    // Seven bools for seven brothers
+    #[derive(Default, PadeEncode)]
+    struct SevenBools {
+        one:   bool,
+        two:   bool,
+        three: bool,
+        four:  bool,
+        five:  bool,
+        six:   bool,
+        seven: bool
+    }
+    let seven_test = SevenBools::default();
+    seven_test.pade_encode();
+
+    #[derive(Default, PadeEncode)]
+    struct EightBools {
+        one:   bool,
+        two:   bool,
+        three: bool,
+        four:  bool,
+        five:  bool,
+        six:   bool,
+        seven: bool,
+        eight: bool
+    }
+    let eight_test = EightBools::default();
+    eight_test.pade_encode();
+}


### PR DESCRIPTION
Fixes a small PADE bug where we split the header BitVec and if its length is precisely a multiple of eight we try to index into an empty vec.  Add a test to cover this situation and the off-by-one 7 situation.