### PR TITLE
Pade fixes for Option and bit encoding

### DIFF
--- a/crates/pade-macro/src/decode.rs
+++ b/crates/pade-macro/src/decode.rs
@@ -54,9 +54,9 @@ fn build_struct_impl(name: &Ident, generics: &Generics, s: &DataStruct) -> Token
                                 let is_enum = Some(<#field_type as pade::PadeEncode>::PADE_VARIANT_MAP_BITS).filter(|b| b != &0);
                                 let #name = if let Some(e) = is_enum {
                                     // the split here naturally will extract out the bitmap fields
-                                        let decode = bitmap.split_off(bitmap_bits - e);
-                                        bitmap_bits -= e;
-                                        let var_e: u8 = pade::bitvec::field::BitField::load_be(&decode);
+                                        let (decode, remainder) = bitmap.split_at(e);
+                                        let var_e: u8 = pade::bitvec::field::BitField::load_le(decode);
+                                        bitmap = remainder.to_bitvec();
                                      <#field_type>::pade_decode_with_width(buf, #w, Some(var_e))?
                                 } else {
                                      <#field_type>::pade_decode_with_width(buf, #w, None)?
@@ -76,9 +76,9 @@ fn build_struct_impl(name: &Ident, generics: &Generics, s: &DataStruct) -> Token
                         let is_enum = Some(<#field_type as pade::PadeEncode>::PADE_VARIANT_MAP_BITS).filter(|b| b != &0);
                         let #name = if let Some(e) = is_enum {
                             // the split here naturally will extract out the bitmap fields
-                            let decode = bitmap.split_off(bitmap_bits - e);
-                            bitmap_bits -= e;
-                            let var_e: u8 = pade::bitvec::field::BitField::load_be(&decode);
+                            let (decode, remainder) = bitmap.split_at(e);
+                            let var_e: u8 = pade::bitvec::field::BitField::load_le(decode);
+                            bitmap = remainder.to_bitvec();
                              <#field_type>::pade_decode(buf, Some(var_e))?
                         } else {
                              <#field_type>::pade_decode(buf, None)?
@@ -113,8 +113,8 @@ fn build_struct_impl(name: &Ident, generics: &Generics, s: &DataStruct) -> Token
                   <#tys as pade::PadeEncode>::PADE_VARIANT_MAP_BITS;
               )*
              let bitmap_bytes = bitmap_bits.div_ceil(8);
-              let mut bitmap = pade::bitvec::vec::BitVec::<u8, pade::bitvec::order::Msb0>::from_slice(&buf[0..bitmap_bytes]);
-              bitmap = bitmap.split_off(bitmap_bytes * 8 - bitmap_bits);
+              let mut bitmap = pade::bitvec::vec::BitVec::<u8, pade::bitvec::order::Lsb0>::from_slice(&buf[0..bitmap_bytes]);
+              let _remainder = bitmap.split_off(bitmap_bits);
               *buf = &buf[bitmap_bytes..];
 
               #(#field_decoders)*

--- a/crates/pade-macro/tests/complex.rs
+++ b/crates/pade-macro/tests/complex.rs
@@ -2,6 +2,60 @@ use pade::{PadeDecode, PadeEncode};
 use pade_macro::{PadeDecode, PadeEncode};
 
 #[test]
+fn enums_have_correct_variant_bit_width() {
+    #[derive(PadeEncode)]
+    enum OneOption {
+        Dave
+    }
+
+    #[derive(PadeEncode)]
+    enum TwoOptions {
+        Dave,
+        #[allow(dead_code)]
+        Knave
+    }
+
+    #[derive(PadeEncode)]
+    #[allow(dead_code)]
+    enum ThreeOptions {
+        Dave,
+        Knave,
+        ToBlave
+    }
+
+    #[derive(PadeEncode)]
+    #[allow(dead_code)]
+    enum FiveOptions {
+        Dave,
+        Knave,
+        ToBlave,
+        Shave,
+        Grave
+    }
+
+    assert_eq!(
+        OneOption::Dave.pade_variant_map_bits(),
+        1,
+        "Wrong number of variant bits for One option"
+    );
+    assert_eq!(
+        TwoOptions::Dave.pade_variant_map_bits(),
+        1,
+        "Wrong number of variant bits for Two option"
+    );
+    assert_eq!(
+        ThreeOptions::Dave.pade_variant_map_bits(),
+        2,
+        "Wrong number of variant bits for Three option"
+    );
+    assert_eq!(
+        FiveOptions::Dave.pade_variant_map_bits(),
+        3,
+        "Wrong number of variant bits for Five option"
+    );
+}
+
+#[test]
 fn supports_struct_with_enum() {
     #[derive(PadeEncode, PadeDecode, PartialEq, Eq, Debug)]
     struct OuterStruct {
@@ -82,6 +136,8 @@ fn bool_ordering_more_than_1byte() {
 
     let encoded = outer.pade_encode();
     let mut slice = encoded.as_slice();
+    println!("{:08b}", slice[0]);
+    println!("{:08b}", slice[1]);
     let decoded = OuterStruct::pade_decode(&mut slice, None).unwrap();
 
     assert_eq!(outer, decoded);
@@ -141,7 +197,82 @@ fn bool_ordering_lower() {
 
     let encoded = outer.pade_encode();
     let mut slice = encoded.as_slice();
+    println!("{:08b}", slice[0]);
     let decoded = OuterStruct::pade_decode(&mut slice, None).unwrap();
 
     assert_eq!(outer, decoded);
+}
+
+#[test]
+fn option_struct() {
+    #[derive(Debug, PadeEncode, PadeDecode, PartialEq, Eq)]
+    struct TestStruct {
+        pub number:     u32,
+        pub option:     Option<u128>,
+        pub number_two: u32,
+        pub bool:       bool
+    }
+
+    let s = TestStruct { number: 100, option: Some(95), number_two: 200, bool: true };
+    let bytes = s.pade_encode();
+    let mut slice = bytes.as_slice();
+    let decoded = TestStruct::pade_decode(&mut slice, None).unwrap();
+
+    assert_eq!(s, decoded);
+}
+
+#[test]
+fn super_specific_dave_test() {
+    #[derive(Debug, PadeEncode, PadeDecode, PartialEq, Eq)]
+    pub enum OrderQuantities {
+        Exact { quantity: u128 },
+        Partial { min_quantity_in: u128, max_quantity_in: u128, filled_quantity: u128 }
+    }
+
+    #[derive(Debug, PadeEncode, PadeDecode, PartialEq, Eq)]
+    enum Signature {
+        TypeOne,
+        TypeTwo
+    }
+    #[derive(Debug, PadeEncode, PadeDecode, PartialEq, Eq)]
+    struct UserOrder {
+        pub ref_id:               u32,
+        pub use_internal:         bool,
+        pub pair_index:           u16,
+        pub min_price:            alloy::primitives::U256,
+        pub recipient:            Option<alloy::primitives::Address>,
+        pub hook_data:            Option<alloy::primitives::Bytes>,
+        pub zero_for_one:         bool,
+        pub standing_validation:  Option<u8>,
+        pub order_quantities:     OrderQuantities,
+        pub max_extra_fee_asset0: u128,
+        pub extra_fee_asset0:     u128,
+        pub exact_in:             bool,
+        pub signature:            Signature
+    }
+
+    let item = UserOrder {
+        ref_id:               25,
+        use_internal:         false,
+        pair_index:           50,
+        min_price:            alloy::primitives::U256::from(29769_u128),
+        recipient:            None,
+        hook_data:            None,
+        zero_for_one:         true,
+        standing_validation:  None,
+        order_quantities:     OrderQuantities::Partial {
+            min_quantity_in: 0,
+            max_quantity_in: 99,
+            filled_quantity: 0
+        },
+        max_extra_fee_asset0: 0,
+        extra_fee_asset0:     0,
+        exact_in:             false,
+        signature:            Signature::TypeTwo
+    };
+    let bytes = item.pade_encode();
+    let mut slice = bytes.as_slice();
+    let decoded = UserOrder::pade_decode(&mut slice, None).unwrap();
+
+    assert_eq!(item, decoded);
 }

--- a/crates/pade/src/decode.rs
+++ b/crates/pade/src/decode.rs
@@ -47,13 +47,16 @@ impl<T: PadeDecode + Debug, const N: usize> PadeDecode for [T; N] {
 // Option<T: PadeEncode> encodes as an enum
 impl<T: PadeDecode> PadeDecode for Option<T> {
     fn pade_decode(buf: &mut &[u8], var: Option<u8>) -> Result<Self, PadeDecodeError> {
-        if buf.is_empty() {
-            return Err(PadeDecodeError::InvalidSize)
-        }
-        // check first byte;
-        let ctr = buf[0] != 0;
-        // progress buffer
-        *buf = &buf[1..];
+        let ctr = if let Some(v) = var {
+            v != 0
+        } else {
+            if buf.is_empty() {
+                return Err(PadeDecodeError::InvalidSize);
+            }
+            let result = buf[0] != 0;
+            *buf = &buf[1..];
+            result
+        };
 
         if ctr {
             Ok(Some(T::pade_decode(buf, var)?))
@@ -67,13 +70,16 @@ impl<T: PadeDecode> PadeDecode for Option<T> {
         width: usize,
         var: Option<u8>
     ) -> Result<Self, PadeDecodeError> {
-        if buf.is_empty() {
-            return Err(PadeDecodeError::InvalidSize)
-        }
-        // check first byte;
-        let ctr = buf[0] != 0;
-        // progress buffer
-        *buf = &buf[1..];
+        let ctr = if let Some(v) = var {
+            v != 0
+        } else {
+            if buf.is_empty() {
+                return Err(PadeDecodeError::InvalidSize);
+            }
+            let result = buf[0] != 0;
+            *buf = &buf[1..];
+            result
+        };
 
         if ctr {
             Ok(Some(T::pade_decode_with_width(buf, width, var)?))

--- a/crates/pade/src/header.rs
+++ b/crates/pade/src/header.rs
@@ -1,0 +1,63 @@
+use std::cmp::min;
+
+use bitvec::{order::Lsb0, vec::BitVec, view::BitView};
+
+#[derive(Debug, Default)]
+pub struct HeaderBits {
+    inner: BitVec<u8, Lsb0>
+}
+
+impl HeaderBits {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn add_bits(&mut self, bytes: &[u8], bits: usize) {
+        // 0 is fine, but we can never take more length than we have bytes
+        let bits_to_take = min(bits, bytes.len() * 8);
+
+        let nview = BitView::view_bits::<Lsb0>(bytes)
+            .split_at(bits_to_take)
+            .0
+            .to_bitvec();
+        self.inner.extend_from_bitslice(nview.as_bitslice());
+    }
+
+    pub fn into_vec(self) -> Vec<u8> {
+        self.inner.into_vec()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::HeaderBits;
+
+    #[test]
+    fn can_be_constructed() {
+        let _h = HeaderBits::new();
+    }
+
+    #[test]
+    fn empty_struct_outputs_zero() {
+        let h = HeaderBits::new();
+        let v = h.into_vec();
+        assert_eq!(v.len(), 0, "Byte vector for empty header not equal to zero");
+
+        let mut h2 = HeaderBits::new();
+        h2.add_bits(&[13_u8], 0);
+        let v2 = h2.into_vec();
+        assert_eq!(v2.len(), 0, "Byte vector not empty after adding zero bits");
+    }
+
+    #[test]
+    fn will_not_oversize_add() {
+        let mut h = HeaderBits::new();
+        h.add_bits(&[u8::MAX], 12);
+        assert_eq!(h.inner.len(), 8, "Too many bits taken from only one byte");
+        h.add_bits(&[u8::MAX, u8::MAX], 20);
+        assert_eq!(h.inner.len(), 24, "Too many bits taken from only one byte");
+        let v = h.into_vec();
+        assert_eq!(v.len(), 3, "Too many bytes generated from a bit over-consumption");
+        assert!(v.iter().all(|x| *x == u8::MAX), "Invalid values in bit output")
+    }
+}

--- a/crates/pade/src/lib.rs
+++ b/crates/pade/src/lib.rs
@@ -1,7 +1,9 @@
 mod decode;
 mod encode;
+mod header;
 mod primitives;
 // Re-export bitvec so our macro crate can rely on it
 pub use bitvec;
 pub use decode::*;
 pub use encode::*;
+pub use header::HeaderBits;


### PR DESCRIPTION
A few PADE fixes
- Fixes how we pack and encode variant bits to be in alignment with the PADE spec (which means in LSB order)
- Fixes a math error that was including extra bits when encoding Enum variants via an off-by-one error with the ilog2 call
- Fixes encoding and decoding of Option types to not falsely return InvalidLength errors