### PR TITLE
Fix JIT reward

### DIFF
--- a/contracts/docs/payload-types.md
+++ b/contracts/docs/payload-types.md
@@ -171,7 +171,8 @@ enum RewardsUpdate {
     MultiTick {
         start_tick: i24,
         start_liquidity: u128,
-        quantities: List<u128>
+        quantities: List<u128>,
+        reward_checksum: u80
     },
     CurrentOnly {
         amount: u128
@@ -194,6 +195,7 @@ as the loop progresses to ensure consistency of reward distribution.
 |`start_liquidity: u128`|The current liquidity if `start_tick` were the current tick.|
 |`quantities: List<u128>`|The reward for each initialized tick range *including* the current tick in
 `asset0` base units.|
+|`reward_checksum: u80`|The upper 80-bits of the "reward checksum", the hash chain of the liquidity and ticks traversed for reward|
 
 **Reward Update Internals**
 

--- a/contracts/src/types/CalldataReader.sol
+++ b/contracts/src/types/CalldataReader.sol
@@ -115,6 +115,14 @@ library CalldataReaderLib {
         return (self, value);
     }
 
+    function readU80(CalldataReader self) internal pure returns (CalldataReader, uint80 value) {
+        assembly ("memory-safe") {
+            value := shr(176, calldataload(self))
+            self := add(self, 10)
+        }
+        return (self, value);
+    }
+
     function readU128(CalldataReader self) internal pure returns (CalldataReader, uint128 value) {
         assembly ("memory-safe") {
             value := shr(128, calldataload(self))

--- a/contracts/test/_helpers/PoolGate.sol
+++ b/contracts/test/_helpers/PoolGate.sol
@@ -169,8 +169,8 @@ contract PoolGate is IUnlockCallback, CommonBase, BaseTest {
         bytes32 delta1Slot = keccak256(abi.encode(sender, asset1));
         bytes32 rawDelta0 = UNI_V4.exttload(delta0Slot);
         bytes32 rawDelta1 = UNI_V4.exttload(delta1Slot);
-        delta = delta
-            + toBalanceDelta(int128(int256(uint256(rawDelta0))), int128(int256(uint256(rawDelta1))));
+        delta =
+            toBalanceDelta(int128(int256(uint256(rawDelta0))), int128(int256(uint256(rawDelta1))));
 
         require(delta.amount0() >= 0 && delta.amount1() >= 0, "losing money for removing liquidity");
         _clear(asset0, asset1, delta);

--- a/contracts/test/_helpers/tests/RewardLib.t.sol
+++ b/contracts/test/_helpers/tests/RewardLib.t.sol
@@ -268,12 +268,22 @@ contract RewardLibTest is BaseTest {
         pure
         returns (RewardsUpdate memory)
     {
+        return MultiTickReward(startTick, startLiquidity, quantities, 0);
+    }
+
+    function MultiTickReward(
+        int24 startTick,
+        uint128 startLiquidity,
+        uint128[] memory quantities,
+        uint72 rewardChecksum
+    ) internal pure returns (RewardsUpdate memory) {
         return RewardsUpdate({
             onlyCurrent: false,
             onlyCurrentQuantity: 0,
             startTick: startTick,
             startLiquidity: startLiquidity,
-            quantities: quantities
+            quantities: quantities,
+            rewardChecksum: rewardChecksum
         });
     }
 

--- a/contracts/test/_reference/PoolUpdate.sol
+++ b/contracts/test/_reference/PoolUpdate.sol
@@ -19,6 +19,7 @@ struct RewardsUpdate {
     int24 startTick;
     uint128 startLiquidity;
     uint128[] quantities;
+    uint80 rewardChecksum;
 }
 
 using PoolUpdateLib for PoolUpdate global;
@@ -68,7 +69,10 @@ library PoolUpdateLib {
             bytes.concat(bytes3(encodedQuantities.length.toUint24()), encodedQuantities);
 
         return bytes.concat(
-            bytes3(uint24(self.startTick)), bytes16(self.startLiquidity), encodedQuantities
+            bytes3(uint24(self.startTick)),
+            bytes16(self.startLiquidity),
+            encodedQuantities,
+            bytes10(self.rewardChecksum)
         );
     }
 


### PR DESCRIPTION
- adds a `reward_checksum: u80` field to the `MultiTick` reward variant to ensure that any JIT liquidity change reverts the bundle
- adds the **security requirement** that some non-negligible amount is swapped in the end current tick, because even with the new mechanism if there is no swapping going through the final tick a reward to it could be JITed without consequences. 
- how to compute the checksum is documented under `Reward Update Internals` 