### PR TITLE
add support for TWÅP orders

### DIFF
--- a/contracts/docs/payload-types.md
+++ b/contracts/docs/payload-types.md
@@ -338,3 +338,56 @@ enum OrderQuantities {
 |-----|-----------|
 |`nonce: u64`|The order's nonce (can only be used once but do not have to be used in order).|
 |`deadline: u40`|The unix timestamp in seconds (inclusive) after which the order is considered invalid by the contract. |
+
+#### `TwapOrder`
+
+```rust
+struct TwapOrder {
+    ref_id: u32,
+    use_internal: bool,
+    pair_index: u16,
+    min_price: u256,
+    recipient: Option<address>,
+    hook_data: Option<List<bytes1>>,
+    zero_for_one: bool,
+    twap_data: TwapData,
+    max_extra_fee_asset0: u128,
+    extra_fee_asset0: u128,
+    exact_in: bool,
+    signature: Signature
+}
+
+struct TwapData {
+    nonce: u64,
+    start_time: u40,
+    total_parts: u32,
+    time_interval: u32,
+    window: u32
+}
+```
+
+**`TwapOrder`**
+
+|Field|Description|
+|-----|-----------|
+|`ref_id: uint32`|Opt-in tag for source of order flow. May opt the user into being charged extra fees beyond gas.|
+|`use_internal: bool`|Whether to use angstrom internal balance (`true`) or actual ERC20 balance (`false`) to settle|
+|`pair_index: u16`|The index into the `List<Pair>` array that the order is trading in.|
+|`min_price: u256`|The minimum price in asset out over asset in base units in RAY|
+|`recipient: Option<address>`|Recipient for order output, `None` implies signer.|
+|`hook_data: Option<List<bytes1>>`|Optional hook for composable orders, consisting of the hook address concatenated to the hook extra data.|
+|`zero_for_one: bool`|Whether the order is swapping in the pair's `asset0` and getting out `asset1` (`true`) or the other way around (`false`)|
+|`twap_data: TwapData`|Specifies how the order will be executed over time.|
+|`max_extra_fee_asset0: u128`|The maximum gas + referral fee the user accepts to be charged (in asset0 base units)|
+|`extra_fee_asset0: u128`|The actual extra fee the user ended up getting charged for their order (in asset0 base units)|
+|`exact_in: bool`|Whether the specified quantity is the input or output.|
+|`signature: Signature`|The signature validating the order.|
+
+**`TwapData`**
+|Field|Description|
+|-----|-----------|
+|`nonce: u64`|The order's nonce (can only be used once but do not have to be used in order).|
+|`start_time: u40`|The unix timestamp from which the order becomes valid (or, after which the order is considered active). |
+|`total_parts: u32`| The maximum number of times the twap order can be executed. |
+|`time_interval: u32`| The required period between consecutive twap orders. |
+|`window: u32`| The specified period when twap orders can be executed. |

--- a/contracts/src/Angstrom.sol
+++ b/contracts/src/Angstrom.sol
@@ -326,7 +326,7 @@ contract Angstrom is
                 ? SignatureLib.readAndCheckEcdsa(reader, orderHash)
                 : SignatureLib.readAndCheckERC1271(reader, orderHash);
         }
-
+    
         _checkTWAPOrderData(buffer.timeInterval, buffer.totalParts, buffer.window);
         _invalidatePartTWAPNonceAndCheckDeadline(
             from, 
@@ -347,7 +347,7 @@ contract Angstrom is
         hook.tryTrigger(from);
 
         _settleOrderIn(from, buffer.assetIn, amountIn, buffer.useInternal);
-
+        console.log("end test");
         return reader;
     }
 

--- a/contracts/src/Angstrom.sol
+++ b/contracts/src/Angstrom.sol
@@ -74,9 +74,11 @@ contract Angstrom is
         reader = _updatePools(reader, pairs);
         console.log("updated pools");
         reader = _validateAndExecuteToBOrders(reader, pairs);
-        console.log("exectued tob");
+        console.log("executed tob");
         reader = _validateAndExecuteUserOrders(reader, pairs);
         console.log("executed user");
+        reader = _validateAndExecuteTWAPOrders(reader, pairs);
+        console.log("executed twap");
         reader.requireAtEndOf(data);
         _saveAndSettle(assets);
 
@@ -272,6 +274,8 @@ contract Angstrom is
         CalldataReader end;
         (reader, end) = reader.readU24End();
 
+        // Purposefully devolve into an endless loop if the specified length isn't exactly used s.t.
+        // `reader == end` at some point.
         while (reader != end) {
             reader = _validateAndExecuteTWAPOrder(reader, buffer, typedHasher, pairs);
         }

--- a/contracts/src/Angstrom.sol
+++ b/contracts/src/Angstrom.sol
@@ -319,20 +319,22 @@ contract Angstrom is
         AmountOut amountOut;
         (reader, amountIn, amountOut) = buffer.loadAndComputeQuantity(reader, variantMap, price);
 
-        bytes32 orderHash = typedHasher.hashTypedData(buffer.hash());
-
         address from;
-        (reader, from) = variantMap.isEcdsa()
-            ? SignatureLib.readAndCheckEcdsa(reader, orderHash)
-            : SignatureLib.readAndCheckERC1271(reader, orderHash);
+        {
+            bytes32 orderHash = typedHasher.hashTypedData(buffer.hash());
+            (reader, from) = variantMap.isEcdsa()
+                ? SignatureLib.readAndCheckEcdsa(reader, orderHash)
+                : SignatureLib.readAndCheckERC1271(reader, orderHash);
+        }
 
-        _checkTWAPOrderData(buffer.timeInterval, buffer.totalParts);
+        _checkTWAPOrderData(buffer.timeInterval, buffer.totalParts, buffer.window);
         _invalidatePartTWAPNonceAndCheckDeadline(
             from, 
             buffer.nonce, 
             buffer.startTime, 
             buffer.timeInterval, 
-            buffer.totalParts
+            buffer.totalParts,
+            buffer.window
         );
 
         // Push before hook as a potential loan.

--- a/contracts/src/modules/OrderInvalidation.sol
+++ b/contracts/src/modules/OrderInvalidation.sol
@@ -6,12 +6,70 @@ abstract contract OrderInvalidation {
     error NonceReuse();
     error OrderAlreadyExecuted();
     error Expired();
+    error TWAPNonceReuse();
+    error TWAPExpired();
+    error InvalidTWAPNonce();
+    error InvalidTWAPOrder();
 
     /// @dev `keccak256("angstrom-v1_0.unordered-nonces.slot")[0:4]`
     uint256 private constant UNORDERED_NONCES_SLOT = 0xdaa050e9;
+    /// @dev `keccak256("angstrom-v1_0.twap-unordered-nonces.slot")[0:4]`
+    uint256 private constant UNORDERED_TWAP_NONCES_SLOT = 0x635a0808;
+    // type(uint32).max
+    uint256 private constant MASK_U32 = 4294967295;
+    // type(uint40).max
+    uint256 private constant MASK_U40 = 1099511627775;
+    // type(uint64).max
+    uint256 private constant MASK_U64 = 18446744073709551615;
+    // type(uint232).max
+    uint256 private constant MASK_U232 = 6901746346790563787434755862277025452451108972170386555162524223799295;
+    // max upper limit of twap intervals = once very 365.25 days
+    uint256 private constant MAX_TWAP_INTERVAL = 0x1e187e0;
+    // max no. of order parts = 365.25 days / 5 seconds
+    uint256 private constant MAX_TWAP_TOTAL_PARTS = 0x604e60;
 
     function invalidateNonce(uint64 nonce) external {
         _invalidateNonce(msg.sender, nonce);
+    }
+
+    function invalidateTWAPNonce(uint64 nonce) external {
+        assembly ("memory-safe") {
+            nonce := and(nonce, MASK_U64)
+            mstore(12, div(nonce, 232))
+            mstore(4, UNORDERED_TWAP_NONCES_SLOT)
+            mstore(0, caller())
+
+            let bitmapPtr := keccak256(12, 32)
+            let flag := shl(mod(nonce, 232), 1)
+            let bitmapVal := sload(bitmapPtr)
+            let updated := xor(and(bitmapVal, MASK_U232) , flag)
+            let twapNonce := iszero(and(updated, flag))
+            let fParts := shr(232, bitmapVal)
+
+            if xor(iszero(iszero(fParts)), twapNonce) {
+                mstore(0x00, 0xcfa42043 /* InvalidTWAPNonce() */ )
+                revert(0x1c, 0x04)
+            }
+
+            if eq(fParts, 0xffffff) {
+                mstore(0x00, 0x9a495418 /* TWAPNonceReuse() */ )
+                revert(0x1c, 0x04)
+            }
+
+            sstore(bitmapPtr, or(updated, shl(232, 0xffffff)))
+        }
+    }
+
+    function _checkTWAPOrderData(uint32 interval, uint32 tParts) internal pure {
+        bool validInterval = interval != 0 && interval < MAX_TWAP_INTERVAL;
+        bool validTParts = tParts != 0 && tParts < MAX_TWAP_TOTAL_PARTS;
+
+        assembly {
+            if iszero(and(validInterval, validTParts)){
+                mstore(0x00, 0x51e490f3 /* InvalidTWAPOrder() */ )
+                revert(0x1c, 0x04)
+            }
+        }
     }
 
     function _checkDeadline(uint256 deadline) internal view {
@@ -35,6 +93,57 @@ abstract contract OrderInvalidation {
             }
 
             sstore(bitmapPtr, updated)
+        }
+    }
+
+    function _invalidatePartTWAPNonceAndCheckDeadline(address owner, uint64 nonce, uint40 sTime, uint32 interval, uint32 tParts) 
+        internal 
+    {
+        uint256 _fParts;
+        assembly ("memory-safe") {
+            nonce := and(nonce, MASK_U64)
+            mstore(12, div(nonce, 232))
+            mstore(4, UNORDERED_TWAP_NONCES_SLOT)
+            mstore(0, owner)
+
+            let bitmapPtr := keccak256(12, 32)
+            let flag := shl(mod(nonce, 232), 1)
+            let bitmapVal := sload(bitmapPtr)
+            let updated := xor(and(bitmapVal, MASK_U232), flag)
+            let twapNonce := iszero(and(updated, flag))
+
+            // part to fulfill
+            let fParts := shr(232, bitmapVal)
+            _fParts := fParts
+
+            if xor(iszero(iszero(fParts)), twapNonce) {
+                mstore(0x00, 0xcfa42043 /* InvalidTWAPNonce() */ )
+                revert(0x1c, 0x04)
+            }
+            
+            fParts := add(fParts, 1)
+            tParts:= and(tParts, MASK_U32)
+
+            if gt(fParts, tParts) {
+                mstore(0x00, 0x9a495418 /* TWAPNonceReuse() */ )
+                revert(0x1c, 0x04)
+            }
+
+            updated := or(shl(232, fParts), flag)
+
+            if iszero(sub(tParts, fParts)) {
+                updated := or(updated, shl(232, 0xffffff))
+            }
+            sstore(bitmapPtr, updated)
+        }
+
+        assembly ("memory-safe") {
+            let cPartStart := add(and(sTime, MASK_U40), mul(_fParts, and(interval, MASK_U32)))
+            
+            if or(lt(timestamp(), cPartStart), gt(timestamp(), add(cPartStart, interval))) {
+                mstore(0x00, 0x982c606d /* TWAPExpired() */ )
+                revert(0x1c, 0x04)
+            }
         }
     }
 

--- a/contracts/src/modules/OrderInvalidation.sol
+++ b/contracts/src/modules/OrderInvalidation.sol
@@ -16,16 +16,18 @@ abstract contract OrderInvalidation {
     /// @dev `keccak256("angstrom-v1_0.twap-unordered-nonces.slot")[0:4]`
     uint256 private constant UNORDERED_TWAP_NONCES_SLOT = 0x635a0808;
     // type(uint32).max
-    uint256 private constant MASK_U32 = 4294967295;
+    uint256 private constant MASK_U32 = 0xffffffff;
     // type(uint40).max
-    uint256 private constant MASK_U40 = 1099511627775;
+    uint256 private constant MASK_U40 = 0xffffffffff;
     // type(uint64).max
-    uint256 private constant MASK_U64 = 18446744073709551615;
+    uint256 private constant MASK_U64 = 0xffffffffffffffff;
     // type(uint232).max
-    uint256 private constant MASK_U232 = 6901746346790563787434755862277025452451108972170386555162524223799295;
-    // max upper limit of twap intervals = once very 365.25 days
+    uint256 private constant MASK_U232 = 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffff;
+    // max twap nonce bit
+    uint256 private constant MAX_TWAP_NONCE_SIZE = 232;
+    // max upper limit of twap intervals = 365.25 days
     uint256 private constant MAX_TWAP_INTERVAL = 0x1e187e0;
-    // max no. of order parts = 365.25 days / 5 seconds
+    // max no. of order parts = 6311520 (365.25 days / 5 seconds)
     uint256 private constant MAX_TWAP_TOTAL_PARTS = 0x604e60;
 
     function invalidateNonce(uint64 nonce) external {
@@ -35,36 +37,36 @@ abstract contract OrderInvalidation {
     function invalidateTWAPNonce(uint64 nonce) external {
         assembly ("memory-safe") {
             nonce := and(nonce, MASK_U64)
-            mstore(12, div(nonce, 232))
+            mstore(12, div(nonce, MAX_TWAP_NONCE_SIZE))
             mstore(4, UNORDERED_TWAP_NONCES_SLOT)
             mstore(0, caller())
 
             let bitmapPtr := keccak256(12, 32)
-            let flag := shl(mod(nonce, 232), 1)
+            let flag := shl(mod(nonce, MAX_TWAP_NONCE_SIZE), 1)
             let bitmapVal := sload(bitmapPtr)
             let updated := xor(and(bitmapVal, MASK_U232) , flag)
             let twapNonce := iszero(and(updated, flag))
-            let fParts := shr(232, bitmapVal)
+            let fulfilledParts := shr(MAX_TWAP_NONCE_SIZE, bitmapVal)
 
-            if xor(iszero(iszero(fParts)), twapNonce) {
+            if xor(iszero(iszero(fulfilledParts)), twapNonce) {
                 mstore(0x00, 0xcfa42043 /* InvalidTWAPNonce() */ )
                 revert(0x1c, 0x04)
             }
 
-            if eq(fParts, 0xffffff) {
+            if eq(fulfilledParts, 0xffffff) {
                 mstore(0x00, 0x9a495418 /* TWAPNonceReuse() */ )
                 revert(0x1c, 0x04)
             }
 
-            sstore(bitmapPtr, or(updated, shl(232, 0xffffff)))
+            sstore(bitmapPtr, or(updated, shl(MAX_TWAP_NONCE_SIZE, 0xffffff)))
         }
     }
 
-    function _checkTWAPOrderData(uint32 interval, uint32 tParts) internal pure {
-        bool validInterval = interval != 0 && interval < MAX_TWAP_INTERVAL;
-        bool validTParts = tParts != 0 && tParts < MAX_TWAP_TOTAL_PARTS;
+    function _checkTWAPOrderData(uint32 interval, uint32 twapParts) internal pure {
+        bool validInterval = interval != 0 && interval <= MAX_TWAP_INTERVAL;
+        bool validTParts = twapParts != 0 && twapParts <= MAX_TWAP_TOTAL_PARTS;
 
-        assembly {
+        assembly("memory-safe") {
             if iszero(and(validInterval, validTParts)){
                 mstore(0x00, 0x51e490f3 /* InvalidTWAPOrder() */ )
                 revert(0x1c, 0x04)
@@ -96,51 +98,54 @@ abstract contract OrderInvalidation {
         }
     }
 
-    function _invalidatePartTWAPNonceAndCheckDeadline(address owner, uint64 nonce, uint40 sTime, uint32 interval, uint32 tParts) 
+    function _invalidatePartTWAPNonceAndCheckDeadline(
+        address owner, 
+        uint64 nonce, 
+        uint40 startTime, 
+        uint32 interval, 
+        uint32 twapParts
+    ) 
         internal 
     {
-        uint256 _fParts;
         assembly ("memory-safe") {
             nonce := and(nonce, MASK_U64)
-            mstore(12, div(nonce, 232))
+            mstore(12, div(nonce, MAX_TWAP_NONCE_SIZE))
             mstore(4, UNORDERED_TWAP_NONCES_SLOT)
             mstore(0, owner)
 
             let bitmapPtr := keccak256(12, 32)
-            let flag := shl(mod(nonce, 232), 1)
+            let flag := shl(mod(nonce, MAX_TWAP_NONCE_SIZE), 1)
             let bitmapVal := sload(bitmapPtr)
             let updated := xor(and(bitmapVal, MASK_U232), flag)
             let twapNonce := iszero(and(updated, flag))
 
             // part to fulfill
-            let fParts := shr(232, bitmapVal)
-            _fParts := fParts
+            let fulfilledParts := shr(MAX_TWAP_NONCE_SIZE, bitmapVal)
+            let _cachedFulfilledParts := fulfilledParts
 
-            if xor(iszero(iszero(fParts)), twapNonce) {
+            if xor(iszero(iszero(fulfilledParts)), twapNonce) {
                 mstore(0x00, 0xcfa42043 /* InvalidTWAPNonce() */ )
                 revert(0x1c, 0x04)
             }
             
-            fParts := add(fParts, 1)
-            tParts:= and(tParts, MASK_U32)
+            fulfilledParts := add(fulfilledParts, 1)
+            twapParts:= and(twapParts, MASK_U32)
 
-            if gt(fParts, tParts) {
+            if gt(fulfilledParts, twapParts) {
                 mstore(0x00, 0x9a495418 /* TWAPNonceReuse() */ )
                 revert(0x1c, 0x04)
             }
 
-            updated := or(shl(232, fParts), flag)
+            updated := or(shl(MAX_TWAP_NONCE_SIZE, fulfilledParts), flag)
 
-            if iszero(sub(tParts, fParts)) {
-                updated := or(updated, shl(232, 0xffffff))
+            if iszero(sub(twapParts, fulfilledParts)) {
+                updated := or(updated, shl(MAX_TWAP_NONCE_SIZE, 0xffffff))
             }
             sstore(bitmapPtr, updated)
-        }
 
-        assembly ("memory-safe") {
-            let cPartStart := add(and(sTime, MASK_U40), mul(_fParts, and(interval, MASK_U32)))
+            let currentPartStart := add(and(startTime, MASK_U40), mul(_cachedFulfilledParts, and(interval, MASK_U32)))
             
-            if or(lt(timestamp(), cPartStart), gt(timestamp(), add(cPartStart, interval))) {
+            if or(lt(timestamp(), currentPartStart), gt(timestamp(), add(currentPartStart, interval))) {
                 mstore(0x00, 0x982c606d /* TWAPExpired() */ )
                 revert(0x1c, 0x04)
             }

--- a/contracts/src/modules/OrderInvalidation.sol
+++ b/contracts/src/modules/OrderInvalidation.sol
@@ -23,6 +23,8 @@ abstract contract OrderInvalidation {
     uint256 private constant MASK_U64 = 0xffffffffffffffff;
     // type(uint232).max
     uint256 private constant MASK_U232 = 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffff;
+    // upper 24 bits mask
+    uint256 private constant UPPER_PART_MASK = 0xffffff0000000000000000000000000000000000000000000000000000000000;
     // max twap nonce bit = 232
     uint256 private constant MAX_TWAP_NONCE_SIZE = 0xe8;
     // max upper limit of twap intervals = 31557600 (365.25 days)
@@ -62,7 +64,7 @@ abstract contract OrderInvalidation {
                 revert(0x1c, 0x04)
             }
 
-            sstore(bitmapPtr, or(flag, shl(MAX_TWAP_NONCE_SIZE, 0xffffff)))
+            sstore(bitmapPtr, or(flag, UPPER_PART_MASK))
         }
     }
 
@@ -147,7 +149,7 @@ abstract contract OrderInvalidation {
             updated := or(shl(MAX_TWAP_NONCE_SIZE, fulfilledParts), flag)
 
             if iszero(sub(twapParts, fulfilledParts)) {
-                updated := or(updated, shl(MAX_TWAP_NONCE_SIZE, 0xffffff))
+                updated := or(updated, UPPER_PART_MASK)
             }
             sstore(bitmapPtr, updated)
 

--- a/contracts/src/modules/OrderInvalidation.sol
+++ b/contracts/src/modules/OrderInvalidation.sol
@@ -23,12 +23,12 @@ abstract contract OrderInvalidation {
     uint256 private constant MASK_U64 = 0xffffffffffffffff;
     // type(uint232).max
     uint256 private constant MASK_U232 = 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffff;
-    // max twap nonce bit
+    // max twap nonce bit = 232
     uint256 private constant MAX_TWAP_NONCE_SIZE = 0xe8;
     // max upper limit of twap intervals = 31557600 (365.25 days)
     uint256 private constant MAX_TWAP_INTERVAL = 0x1e187e0;
-    // min lower limit of twap intervals = 5 seconds
-    uint256 private constant MIN_TWAP_INTERVAL = 0x05;
+    // min lower limit of twap intervals = 12 seconds
+    uint256 private constant MIN_TWAP_INTERVAL = 0x0c;
     // max no. of order parts = 6311520 (365.25 days / 5 seconds)
     uint256 private constant MAX_TWAP_TOTAL_PARTS = 0x604e60;
 
@@ -50,6 +50,8 @@ abstract contract OrderInvalidation {
             let twapNonce := iszero(and(updated, flag))
             let fulfilledParts := shr(MAX_TWAP_NONCE_SIZE, bitmapVal)
 
+            // Reverts if `fulfilledParts` is empty while `twapNonce` is not empty,
+            // or if `fulfilledParts` is not empty while `twapNonce` is empty.
             if xor(iszero(iszero(fulfilledParts)), twapNonce) {
                 mstore(0x00, 0xcfa42043 /* InvalidTWAPNonce() */ )
                 revert(0x1c, 0x04)
@@ -60,7 +62,7 @@ abstract contract OrderInvalidation {
                 revert(0x1c, 0x04)
             }
 
-            sstore(bitmapPtr, or(updated, shl(MAX_TWAP_NONCE_SIZE, 0xffffff)))
+            sstore(bitmapPtr, or(flag, shl(MAX_TWAP_NONCE_SIZE, 0xffffff)))
         }
     }
 
@@ -127,6 +129,8 @@ abstract contract OrderInvalidation {
             let fulfilledParts := shr(MAX_TWAP_NONCE_SIZE, bitmapVal)
             let _cachedFulfilledParts := fulfilledParts
 
+            // Reverts if `fulfilledParts` is empty while `twapNonce` is not empty,
+            // or if `fulfilledParts` is not empty while `twapNonce` is empty.
             if xor(iszero(iszero(fulfilledParts)), twapNonce) {
                 mstore(0x00, 0xcfa42043 /* InvalidTWAPNonce() */ )
                 revert(0x1c, 0x04)

--- a/contracts/src/types/TWAPOrderBuffer.sol
+++ b/contracts/src/types/TWAPOrderBuffer.sol
@@ -1,0 +1,159 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+import {CalldataReader} from "./CalldataReader.sol";
+import {TWAPOrderVariantMap} from "./TWAPOrderVariantMap.sol";
+import {PriceAB as PriceOutVsIn, AmountA as AmountOut, AmountB as AmountIn} from "./Price.sol";
+
+struct TWAPOrderBuffer {
+    bytes32 typeHash;
+    uint32 refId;
+    bool exactIn;
+    uint256 quantity;
+    uint256 maxExtraFeeAsset0;
+    uint256 minPrice;
+    bool useInternal;
+    address assetIn;
+    address assetOut;
+    address recipient;
+    bytes32 hookDataHash;
+    uint64 nonce;
+    uint40 startTime;
+    uint32 totalParts;
+    uint32 timeInterval;
+}
+
+using TWAPOrderBufferLib for TWAPOrderBuffer global;
+
+/// @author philogy <https://github.com/philogy>
+library TWAPOrderBufferLib {
+    error GasAboveMax();
+
+    uint256 internal constant BUFFER_BYTES = 480;
+
+    uint256 internal constant VARIANT_MAP_BYTES = 1;
+    /// @dev Destination offset for direct calldatacopy of 4-byte ref ID (therefore not word aligned).
+    uint256 internal constant REF_ID_MEM_OFFSET = 0x20;
+    uint256 internal constant REF_ID_BYTES = 4;
+    uint256 internal constant NONCE_MEM_OFFSET = 0x160;
+    uint256 internal constant NONCE_BYTES = 8;
+    uint256 internal constant START_TIME_MEM_OFFSET = 0x180;
+    uint256 internal constant START_TIME_BYTES = 5;
+    uint256 internal constant PARTS_MEM_OFFSET = 0x1a0;
+    uint256 internal constant PARTS_BYTES = 4;
+    uint256 internal constant TIME_INTERVALS_MEM_OFFSET = 0x1c0;
+    uint256 internal constant TIME_INTERVALS_BYTES = 4;
+
+    /// forgefmt: disable-next-item
+    bytes32 internal constant TWAP_ORDER_TYPEHASH = keccak256(
+        "TimeWeightedAveragePriceOrder("
+           "uint32 ref_id,"
+           "bool exact_in,"
+           "uint128 amount,"
+           "uint128 max_extra_fee_asset0,"
+           "uint256 min_price,"
+           "bool use_internal,"
+           "address asset_in,"
+           "address asset_out,"
+           "address recipient,"
+           "bytes hook_data,"
+           "uint64 nonce,"
+           "uint40 start_time,"
+           "uint32 total_parts,"
+           "uint32 time_interval"
+        ")"
+    );
+
+    function init(TWAPOrderBuffer memory self, CalldataReader reader)
+        internal
+        pure
+        returns (CalldataReader, TWAPOrderVariantMap variantMap)
+    {
+        assembly ("memory-safe") {
+            variantMap := byte(0, calldataload(reader))
+            reader := add(reader, VARIANT_MAP_BYTES)
+            // Copy `refId` from calldata directly to memory.
+            calldatacopy(
+                add(self, add(REF_ID_MEM_OFFSET, sub(0x20, REF_ID_BYTES))), reader, REF_ID_BYTES
+            )
+            // Advance reader.
+            reader := add(reader, REF_ID_BYTES)
+        }
+        
+        self.typeHash = TWAP_ORDER_TYPEHASH;
+        
+        self.useInternal = variantMap.useInternal();
+
+        return (reader, variantMap);
+   
+    }
+
+    function hash(TWAPOrderBuffer memory self) internal pure returns (bytes32 orderHash) {
+        assembly ("memory-safe") {
+            orderHash := keccak256(self, BUFFER_BYTES)
+        }
+    }
+
+    function loadAndComputeQuantity(
+        TWAPOrderBuffer memory self,
+        CalldataReader reader,
+        TWAPOrderVariantMap variant,
+        PriceOutVsIn price
+    ) internal pure returns (CalldataReader, AmountIn quantityIn, AmountOut quantityOut) {
+        uint256 quantity;
+        (reader, quantity) = reader.readU128();
+        // how is this actually used.
+        // self.exactIn = variant.exactIn();
+        self.quantity = quantity;
+
+        uint128 extraFeeAsset0;
+        uint128 maxExtraFeeAsset0;
+        (reader, maxExtraFeeAsset0) = reader.readU128();
+        (reader, extraFeeAsset0) = reader.readU128();
+        if (extraFeeAsset0 > maxExtraFeeAsset0) revert GasAboveMax();
+        self.maxExtraFeeAsset0 = maxExtraFeeAsset0;
+
+        quantityIn = AmountIn.wrap(quantity);
+        if (variant.zeroForOne()) {
+            AmountIn fee = AmountIn.wrap(extraFeeAsset0);
+            quantityOut = price.convertDown(quantityIn - fee);
+        } else {
+            AmountOut fee = AmountOut.wrap(extraFeeAsset0);
+            quantityOut = price.convertDown(quantityIn) - fee;
+        }
+
+        return (reader, quantityIn, quantityOut);
+    }
+
+    function readOrderValidation(
+        TWAPOrderBuffer memory self,
+        CalldataReader reader
+    ) internal pure returns (CalldataReader) {
+        // Copy slices directly from calldata into memory.
+        assembly ("memory-safe") {
+            calldatacopy(
+                add(self, add(NONCE_MEM_OFFSET, sub(0x20, NONCE_BYTES))), reader, NONCE_BYTES
+            )
+            reader := add(reader, NONCE_BYTES)
+            calldatacopy(
+                add(self, add(START_TIME_MEM_OFFSET, sub(0x20, START_TIME_BYTES))),
+                reader,
+                START_TIME_BYTES
+            )
+            reader := add(reader, START_TIME_BYTES)
+            calldatacopy(
+                add(self, add(PARTS_MEM_OFFSET, sub(0x20, PARTS_BYTES))),
+                reader,
+                PARTS_BYTES
+            )
+            reader := add(reader, PARTS_BYTES)
+            calldatacopy(
+                add(self, add(TIME_INTERVALS_MEM_OFFSET, sub(0x20, TIME_INTERVALS_BYTES))),
+                reader,
+                TIME_INTERVALS_BYTES
+            )
+            reader := add(reader, TIME_INTERVALS_BYTES)
+        }
+        return reader;
+    }
+}

--- a/contracts/src/types/TWAPOrderBuffer.sol
+++ b/contracts/src/types/TWAPOrderBuffer.sol
@@ -21,6 +21,7 @@ struct TWAPOrderBuffer {
     uint40 startTime;
     uint32 totalParts;
     uint32 timeInterval;
+    uint32 window;
 }
 
 using TWAPOrderBufferLib for TWAPOrderBuffer global;
@@ -29,7 +30,7 @@ using TWAPOrderBufferLib for TWAPOrderBuffer global;
 library TWAPOrderBufferLib {
     error GasAboveMax();
 
-    uint256 internal constant BUFFER_BYTES = 480;
+    uint256 internal constant BUFFER_BYTES = 512;
 
     uint256 internal constant VARIANT_MAP_BYTES = 1;
     /// @dev Destination offset for direct calldatacopy of 4-byte ref ID (therefore not word aligned).
@@ -43,6 +44,8 @@ library TWAPOrderBufferLib {
     uint256 internal constant PARTS_BYTES = 4;
     uint256 internal constant TIME_INTERVALS_MEM_OFFSET = 0x1c0;
     uint256 internal constant TIME_INTERVALS_BYTES = 4;
+    uint256 internal constant WINDOW_MEM_OFFSET = 0x1e0;
+    uint256 internal constant WINDOW_BYTES = 4;
 
     /// forgefmt: disable-next-item
     bytes32 internal constant TWAP_ORDER_TYPEHASH = keccak256(
@@ -60,7 +63,8 @@ library TWAPOrderBufferLib {
            "uint64 nonce,"
            "uint40 start_time,"
            "uint32 total_parts,"
-           "uint32 time_interval"
+           "uint32 time_interval,"
+           "uint32 window"
         ")"
     );
 
@@ -164,6 +168,12 @@ library TWAPOrderBufferLib {
                 TIME_INTERVALS_BYTES
             )
             reader := add(reader, TIME_INTERVALS_BYTES)
+            calldatacopy(
+                add(self, add(WINDOW_MEM_OFFSET, sub(0x20, WINDOW_BYTES))),
+                reader,
+                WINDOW_BYTES
+            )
+            reader := add(reader, WINDOW_BYTES)
         }
         return reader;
     }

--- a/contracts/src/types/TWAPOrderVariantMap.sol
+++ b/contracts/src/types/TWAPOrderVariantMap.sol
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+type TWAPOrderVariantMap is uint8;
+
+using TWAPOrderVariantMapLib for TWAPOrderVariantMap global;
+
+/// @author philogy <https://github.com/philogy>
+library TWAPOrderVariantMapLib {
+    uint256 internal constant USE_INTERNAL_BIT = 0x01;
+    uint256 internal constant HAS_RECIPIENT_BIT = 0x02;
+    uint256 internal constant HAS_HOOK_BIT = 0x04;
+    uint256 internal constant ZERO_FOR_ONE_BIT = 0x08;
+    uint256 internal constant IS_EXACT_IN_BIT = 0x10;
+    uint256 internal constant IS_ECDSA_BIT = 0x20;
+
+
+    function useInternal(TWAPOrderVariantMap variant) internal pure returns (bool) {
+        return TWAPOrderVariantMap.unwrap(variant) & USE_INTERNAL_BIT != 0;
+    }
+
+    function recipientIsSome(TWAPOrderVariantMap variant) internal pure returns (bool) {
+        return TWAPOrderVariantMap.unwrap(variant) & HAS_RECIPIENT_BIT != 0;
+    }
+
+    function noHook(TWAPOrderVariantMap variant) internal pure returns (bool) {
+        return TWAPOrderVariantMap.unwrap(variant) & HAS_HOOK_BIT == 0;
+    }
+
+    function zeroForOne(TWAPOrderVariantMap variant) internal pure returns (bool) {
+        return TWAPOrderVariantMap.unwrap(variant) & ZERO_FOR_ONE_BIT != 0;
+    }
+
+    function exactIn(TWAPOrderVariantMap variant) internal pure returns (bool) {
+        return TWAPOrderVariantMap.unwrap(variant) & IS_EXACT_IN_BIT != 0;
+    }
+
+    function isEcdsa(TWAPOrderVariantMap variant) internal pure returns (bool) {
+        return TWAPOrderVariantMap.unwrap(variant) & IS_ECDSA_BIT != 0;
+    }
+}

--- a/contracts/test/Angstrom.t.sol
+++ b/contracts/test/Angstrom.t.sol
@@ -8,7 +8,11 @@ import {Bundle} from "test/_reference/Bundle.sol";
 import {Asset, AssetLib} from "test/_reference/Asset.sol";
 import {Pair, PairLib} from "test/_reference/Pair.sol";
 import {UserOrder, UserOrderLib} from "test/_reference/UserOrder.sol";
-import {PartialStandingOrder, ExactFlashOrder} from "test/_reference/OrderTypes.sol";
+import {
+    PartialStandingOrder, 
+    ExactFlashOrder,
+    TimeWeightedAveragePriceOrder
+} from "test/_reference/OrderTypes.sol";
 import {PriceAB as Price10} from "src/types/Price.sol";
 import {MockERC20} from "super-sol/mocks/MockERC20.sol";
 
@@ -111,6 +115,94 @@ contract AngstromTest is BaseTest {
         bytes memory payload = bundle.encode(rawGetConfigStore(address(angstrom)));
         vm.prank(node);
         angstrom.execute(payload);
+    }
+
+    function test_twapOrderWithFees() public {
+        uint256 fee = 0.002e6;
+
+        vm.prank(controller);
+        angstrom.configurePool(asset0, asset1, 1, uint24(fee), 0);
+
+        console.log("asset0: %s", asset0);
+        console.log("asset1: %s", asset1);
+
+        Account memory user1 = makeAccount("user_1");
+        MockERC20(asset0).mint(user1.addr, 100.0e18);
+        vm.prank(user1.addr);
+        MockERC20(asset0).approve(address(angstrom), type(uint256).max);
+
+        Account memory user2 = makeAccount("user_2");
+        MockERC20(asset1).mint(user2.addr, 100.0e18);
+        vm.prank(user2.addr);
+        MockERC20(asset1).approve(address(angstrom), type(uint256).max);
+
+        Price10 price = Price10.wrap(1e27);
+
+        Bundle memory bundle;
+
+        bundle.addAsset(asset0).addAsset(asset1).addPair(asset0, asset1, price);
+
+        uint256 startTime = block.timestamp;
+        uint256 timeInterval; 
+
+        {
+            TimeWeightedAveragePriceOrder memory order;
+            order.exactIn = true;
+            order.amount = 10.0e18;
+            order.maxExtraFeeAsset0 = 1.3e18;
+            order.minPrice = 0.1e27;
+            order.assetIn = asset0;
+            order.assetOut = asset1;
+            order.nonce = 18446744073709551615;
+            order.startTime = u40(block.timestamp);
+            order.totalParts = 3;
+            order.timeInterval = 12 seconds;
+            order.window = order.timeInterval;
+            sign(user1, order.meta, digest712(order.hash()));
+            order.extraFeeAsset0 = 1.0e18;
+            bundle.addTwap(order);
+            timeInterval = order.timeInterval;
+        }
+
+        {
+            TimeWeightedAveragePriceOrder memory order;
+            order.exactIn = true;
+            order.amount = 9.200400801603206413e18;
+            order.maxExtraFeeAsset0 = 0.2e18;
+            order.minPrice = 0.1e27;
+            order.assetIn = asset1;
+            order.assetOut = asset0;
+            order.nonce = 18446744073709551515;
+            order.startTime = u40(block.timestamp);
+            order.totalParts = 3;
+            order.timeInterval = 12 seconds;
+            order.window = order.timeInterval;
+            sign(user2, order.meta, digest712(order.hash()));
+            order.extraFeeAsset0 = 0.2e18;
+            bundle.addTwap(order);
+        }
+
+        bundle.assets[0].save += 1.018e18;
+        bundle.assets[1].save += 0.218400801603206413e18;
+        bundle.assets[1].take += 10.0e18;
+        bundle.assets[1].settle += 10.0e18;
+
+        bytes memory payload = bundle.encode(rawGetConfigStore(address(angstrom)));
+        vm.startPrank(node);
+
+        angstrom.execute(payload);
+
+        // only one bundle per block.
+        vm.roll(block.number + 1);
+        vm.warp(startTime + timeInterval);
+        angstrom.execute(payload);
+
+        // only one bundle per block.
+        vm.roll(block.number + 2);
+        vm.warp(startTime + 2*(timeInterval));
+        angstrom.execute(payload);
+
+        vm.stopPrank();
     }
 
     function digest712(bytes32 structHash) internal view returns (bytes32) {

--- a/contracts/test/_helpers/BaseTest.sol
+++ b/contracts/test/_helpers/BaseTest.sol
@@ -110,7 +110,7 @@ contract BaseTest is Test, HookDeployer {
 
     function pythonRunCmd() internal pure returns (string[] memory args) {
         args = new string[](1);
-        args[0] = ".venv/bin/python3.12";
+        args[0] = ".venv/bin/python3.13";
     }
 
     function ffiPython(string[] memory args) internal returns (bytes memory) {

--- a/contracts/test/_helpers/BaseTest.sol
+++ b/contracts/test/_helpers/BaseTest.sol
@@ -110,7 +110,7 @@ contract BaseTest is Test, HookDeployer {
 
     function pythonRunCmd() internal pure returns (string[] memory args) {
         args = new string[](1);
-        args[0] = ".venv/bin/python3.13";
+        args[0] = ".venv/bin/python3.12";
     }
 
     function ffiPython(string[] memory args) internal returns (bytes memory) {

--- a/contracts/test/_helpers/Utils.sol
+++ b/contracts/test/_helpers/Utils.sol
@@ -18,4 +18,21 @@ library Utils {
             bx := xor(shl(64, dirt), x)
         }
     }
+
+    // https://github.com/ethereum/solidity/issues/15144
+    function brutalizeU40(uint40 y) internal view returns (uint40 cx) {
+        assembly ("memory-safe") {
+            mstore(0x00, gas())
+            let dirt := keccak256(0, 32)
+            cx := xor(shl(40, dirt), y)
+        }
+    }
+
+    function brutalizeU32(uint32 z) internal view returns (uint32 dx) {
+        assembly ("memory-safe") {
+            mstore(0x00, gas())
+            let dirt := keccak256(0, 32)
+            dx := xor(shl(32, dirt), z)
+        }
+    }
 }

--- a/contracts/test/_mocks/OpenAngstrom.sol
+++ b/contracts/test/_mocks/OpenAngstrom.sol
@@ -12,6 +12,8 @@ import {ToBOrderBuffer} from "src/types/ToBOrderBuffer.sol";
 import {ToBOrderVariantMap} from "src/types/ToBOrderVariantMap.sol";
 import {UserOrderBuffer} from "src/types/UserOrderBuffer.sol";
 import {UserOrderVariantMap} from "src/types/UserOrderVariantMap.sol";
+import {TWAPOrderBuffer} from "src/types/TWAPOrderBuffer.sol";
+import {TWAPOrderVariantMap} from "src/types/TWAPOrderVariantMap.sol";
 import {PoolId} from "v4-core/src/types/PoolId.sol";
 import {Position} from "src/types/Positions.sol";
 import {PoolConfigStore} from "src/libraries/PoolConfigStore.sol";
@@ -81,6 +83,21 @@ contract OpenAngstrom is Angstrom {
 
         UserOrderBuffer memory buffer;
         reader = _validateAndExecuteUserOrder(reader, buffer, _erc712Hasher(), pairs);
+
+        reader.requireAtEndOf(userOrderPayload);
+    }
+
+    /// @custom:pade (List<Asset>, List<Pair>, UserOrder)
+    function validateAndExecuteTWAPOrder(bytes calldata userOrderPayload) public {
+        CalldataReader reader = CalldataReaderLib.from(userOrderPayload);
+
+        AssetArray assets;
+        (reader, assets) = AssetLib.readFromAndValidate(reader);
+        PairArray pairs;
+        (reader, pairs) = PairLib.readFromAndValidate(reader, assets, _configStore);
+
+        TWAPOrderBuffer memory buffer;
+        reader = _validateAndExecuteTWAPOrder(reader, buffer, _erc712Hasher(), pairs);
 
         reader.requireAtEndOf(userOrderPayload);
     }

--- a/contracts/test/_reference/Bundle.sol
+++ b/contracts/test/_reference/Bundle.sol
@@ -19,7 +19,7 @@ struct Bundle {
     PoolUpdate[] poolUpdates;
     TopOfBlockOrder[] toBOrders;
     UserOrder[] userOrders;
-    // TimeWeightedAveragePriceOrder[] twapOrders;
+    TimeWeightedAveragePriceOrder[] twapOrders;
 }
 
 using BundleLib for Bundle global;
@@ -41,8 +41,8 @@ library BundleLib {
             self.pairs.encode(self.assets, configStore),
             self.poolUpdates.encode(self.pairs),
             self.toBOrders.encode(self.pairs),
-            self.userOrders.encode(self.pairs)
-            // self.twapOrders.encode(self.pairs)
+            self.userOrders.encode(self.pairs),
+            self.twapOrders.encode(self.pairs)
         );
     }
 

--- a/contracts/test/_reference/Bundle.sol
+++ b/contracts/test/_reference/Bundle.sol
@@ -126,6 +126,23 @@ library BundleLib {
         return self;
     }
 
+    function addTwap(Bundle memory self, TimeWeightedAveragePriceOrder memory twap)
+        internal
+        pure
+        returns (Bundle memory)
+    {
+        // self.addPair(twap.assetIn, twap.assetOut);
+
+        TimeWeightedAveragePriceOrder[] memory newTwapOrders = new TimeWeightedAveragePriceOrder[](self.twapOrders.length + 1);
+        for (uint256 i = 0; i < self.twapOrders.length; i++) {
+            newTwapOrders[i] = self.twapOrders[i];
+        }
+        newTwapOrders[self.twapOrders.length] = twap;
+        self.twapOrders = newTwapOrders;
+
+        return self;
+    }
+
     function addDeltas(Bundle memory self, uint256 index0, uint256 index1, BalanceDelta deltas)
         internal
         pure

--- a/contracts/test/_reference/Bundle.sol
+++ b/contracts/test/_reference/Bundle.sol
@@ -5,7 +5,11 @@ import {UserOrder, UserOrderLib} from "./UserOrder.sol";
 import {Asset, AssetLib} from "./Asset.sol";
 import {Pair, PairLib} from "./Pair.sol";
 import {PriceAB as Price10} from "src/types/Price.sol";
-import {TopOfBlockOrder, OrdersLib} from "./OrderTypes.sol";
+import {
+    TopOfBlockOrder,
+    TimeWeightedAveragePriceOrder,
+    OrdersLib
+} from "./OrderTypes.sol";
 import {PoolUpdate, PoolUpdateLib} from "./PoolUpdate.sol";
 import {BalanceDelta} from "v4-core/src/types/BalanceDelta.sol";
 
@@ -15,6 +19,7 @@ struct Bundle {
     PoolUpdate[] poolUpdates;
     TopOfBlockOrder[] toBOrders;
     UserOrder[] userOrders;
+    // TimeWeightedAveragePriceOrder[] twapOrders;
 }
 
 using BundleLib for Bundle global;
@@ -22,6 +27,7 @@ using BundleLib for Bundle global;
 /// @author philogy <https://github.com/philogy>
 library BundleLib {
     using OrdersLib for TopOfBlockOrder[];
+    using OrdersLib for TimeWeightedAveragePriceOrder[];
     using UserOrderLib for UserOrder[];
     using AssetLib for Asset[];
     using PairLib for Pair[];
@@ -36,6 +42,7 @@ library BundleLib {
             self.poolUpdates.encode(self.pairs),
             self.toBOrders.encode(self.pairs),
             self.userOrders.encode(self.pairs)
+            // self.twapOrders.encode(self.pairs)
         );
     }
 

--- a/contracts/test/_reference/OrderTypes.sol
+++ b/contracts/test/_reference/OrderTypes.sol
@@ -125,6 +125,7 @@ struct TimeWeightedAveragePriceOrder {
     uint40 startTime;
     uint32 totalParts;
     uint32 timeInterval;
+    uint32 window;
     OrderMeta meta;
     uint128 extraFeeAsset0;
 }
@@ -236,7 +237,8 @@ library OrdersLib {
             order.nonce,
             order.startTime,
             order.totalParts,
-            order.timeInterval
+            order.timeInterval,
+            order.window
         ).hash();
     }
 
@@ -457,6 +459,7 @@ library OrdersLib {
             bytes5(order.startTime),
             bytes4(order.totalParts),
             bytes4(order.timeInterval),
+            bytes4(order.window),
             bytes16(order.amount),
             bytes16(order.maxExtraFeeAsset0),
             bytes16(order.extraFeeAsset0),
@@ -632,6 +635,8 @@ library OrdersLib {
             o.totalParts.toStr(),
             ",\n  timeInterval: ",
             o.timeInterval.toStr(),
+            ",\n  window: ",
+            o.window.toStr(),
             ",\n  meta: ",
             o.meta.toStr(),
             "\n}"

--- a/contracts/test/_reference/SignedTypes.sol
+++ b/contracts/test/_reference/SignedTypes.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.13;
 
 import {UserOrderBufferLib} from "src/types/UserOrderBuffer.sol";
 import {ToBOrderBufferLib} from "src/types/ToBOrderBuffer.sol";
+import {TWAPOrderBufferLib} from "src/types/TWAPOrderBuffer.sol";
 
 struct PartialStandingOrder {
     uint32 ref_id;
@@ -73,11 +74,29 @@ struct TopOfBlockOrder {
     uint64 valid_for_block;
 }
 
+struct TimeWeightedAveragePriceOrder {
+    uint32 ref_id;
+    bool exact_in;
+    uint128 amount;
+    uint128 max_extra_fee_asset0;
+    uint256 min_price;
+    bool use_internal;
+    address asset_in;
+    address asset_out;
+    address recipient;
+    bytes hook_data;
+    uint64 nonce;
+    uint40 start_time;
+    uint32 total_parts;
+    uint32 time_interval;
+}
+
 using SignedTypesLib for ExactStandingOrder global;
 using SignedTypesLib for PartialStandingOrder global;
 using SignedTypesLib for ExactFlashOrder global;
 using SignedTypesLib for PartialFlashOrder global;
 using SignedTypesLib for TopOfBlockOrder global;
+using SignedTypesLib for TimeWeightedAveragePriceOrder global;
 
 /// @author philogy <https://github.com/philogy>
 library SignedTypesLib {
@@ -173,5 +192,44 @@ library SignedTypesLib {
                 self.valid_for_block
             )
         );
+    }
+
+    struct TimeWeightedAveragePriceOrderMem {
+        bytes32 type_hash;
+        uint32 ref_id;
+        bool exact_in;
+        uint128 amount;
+        uint128 max_extra_fee_asset0;
+        uint256 min_price;
+        bool use_internal;
+        address asset_in;
+        address asset_out;
+        address recipient;
+        bytes32 hook_data_hash;
+        uint64 nonce;
+        uint40 start_time;
+        uint32 total_parts;
+        uint32 time_interval;
+    }
+
+    function hash(TimeWeightedAveragePriceOrder memory self) internal pure returns (bytes32) {
+        TimeWeightedAveragePriceOrderMem memory orderToMem = TimeWeightedAveragePriceOrderMem({
+            type_hash: TWAPOrderBufferLib.TWAP_ORDER_TYPEHASH,
+            ref_id: self.ref_id,
+            exact_in: self.exact_in,
+            amount: self.amount,
+            max_extra_fee_asset0: self.max_extra_fee_asset0,
+            min_price: self.min_price,
+            use_internal: self.use_internal,
+            asset_in: self.asset_in,
+            asset_out: self.asset_out,
+            recipient: self.recipient,
+            hook_data_hash: keccak256(self.hook_data),
+            nonce: self.nonce,
+            start_time: self.start_time,
+            total_parts: self.total_parts,
+            time_interval: self.time_interval
+        });
+        return keccak256(abi.encode(orderToMem));
     }
 }

--- a/contracts/test/_reference/SignedTypes.sol
+++ b/contracts/test/_reference/SignedTypes.sol
@@ -89,6 +89,7 @@ struct TimeWeightedAveragePriceOrder {
     uint40 start_time;
     uint32 total_parts;
     uint32 time_interval;
+    uint32 window;
 }
 
 using SignedTypesLib for ExactStandingOrder global;
@@ -210,6 +211,7 @@ library SignedTypesLib {
         uint40 start_time;
         uint32 total_parts;
         uint32 time_interval;
+        uint32 window;
     }
 
     function hash(TimeWeightedAveragePriceOrder memory self) internal pure returns (bytes32) {
@@ -228,7 +230,8 @@ library SignedTypesLib {
             nonce: self.nonce,
             start_time: self.start_time,
             total_parts: self.total_parts,
-            time_interval: self.time_interval
+            time_interval: self.time_interval,
+            window: self.window
         });
         return keccak256(abi.encode(orderToMem));
     }

--- a/contracts/test/benchmark/TWAPOrder.b.sol
+++ b/contracts/test/benchmark/TWAPOrder.b.sol
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {BaseTest} from "test/_helpers/BaseTest.sol";
+import {OpenAngstrom} from "test/_mocks/OpenAngstrom.sol";
+import {Pair, PairLib} from "test/_reference/Pair.sol";
+import {Asset, AssetLib} from "test/_reference/Asset.sol";
+import {Bundle} from "test/_reference/Bundle.sol";
+import {PoolConfigStore} from "src/libraries/PoolConfigStore.sol";
+import {MockERC20} from "super-sol/mocks/MockERC20.sol";
+import {PoolManager} from "v4-core/src/PoolManager.sol";
+import {TimeWeightedAveragePriceOrder} from "../_reference/OrderTypes.sol";
+import {PriceAB} from "src/types/Price.sol";
+
+import {console} from "forge-std/console.sol";
+
+/// @author philogy <https://github.com/philogy>
+contract TWAPOrderBenchmarkTest is BaseTest {
+    using AssetLib for *;
+    using PairLib for *;
+
+    OpenAngstrom angstrom;
+    PoolManager uni;
+
+    address asset0;
+    address asset1;
+
+    address fee_master = makeAddr("fee_master");
+    address controller = makeAddr("controller");
+    address node = makeAddr("the_one");
+
+    function setUp() public {
+        uni = new PoolManager(address(0));
+        angstrom = OpenAngstrom(deployAngstrom(type(OpenAngstrom).creationCode, uni, controller));
+        (asset0, asset1) = deployTokensSorted();
+        vm.startPrank(controller);
+        angstrom.configurePool(asset0, asset1, 1, 0, 0);
+        angstrom.toggleNodes(addressArray(abi.encode(node)));
+        vm.stopPrank();
+    }
+
+    function test_benchmark_TwapOrder() public {
+        Account memory user = makeAccount("user");
+
+        uint128 balance = 3.3e18;
+        MockERC20(asset0).mint(user.addr, balance);
+        uint128 other = 34_000e18;
+        MockERC20(asset1).mint(user.addr, other);
+        vm.startPrank(user.addr);
+        MockERC20(asset0).approve(address(angstrom), type(uint256).max);
+        angstrom.deposit(asset0, balance);
+        MockERC20(asset1).approve(address(angstrom), type(uint256).max);
+        angstrom.deposit(asset1, other);
+        vm.stopPrank();
+
+        TimeWeightedAveragePriceOrder memory order;
+        order.exactIn = true;
+        order.amount = 1e18;
+        order.maxExtraFeeAsset0 = 0;
+        order.minPrice = 10.0e27;
+        order.useInternal = true;
+        order.assetIn = asset0;
+        order.assetOut = asset1;
+        order.nonce = 18446744073709551615;
+        order.startTime = u40(block.timestamp);
+        order.totalParts = 3;
+        order.timeInterval = 12 seconds;
+        order.window = order.timeInterval;
+        sign(user, order.meta, erc712Hash(computeDomainSeparator(address(angstrom)), order.hash()));
+
+        Asset[] memory assets = new Asset[](2);
+        assets[0].addr = asset0;
+        assets[1].addr = asset1;
+        Pair[] memory pair = new Pair[](1);
+        pair[0] = Pair(asset0, asset1, PriceAB.wrap(11.5e27));
+
+        bytes memory payload = bytes.concat(
+            assets.encode(),
+            pair.encode(assets, PoolConfigStore.unwrap(angstrom.configStore())),
+            order.encode(pair)
+        );
+
+        angstrom.validateAndExecuteTWAPOrder(payload);
+        vm.warp(order.startTime + order.timeInterval);
+        angstrom.validateAndExecuteTWAPOrder(payload);
+        vm.warp(order.startTime + 2*(order.timeInterval));
+        angstrom.validateAndExecuteTWAPOrder(payload);
+    }
+}

--- a/contracts/test/modules/OrderInvalidation.t.sol
+++ b/contracts/test/modules/OrderInvalidation.t.sol
@@ -11,7 +11,7 @@ contract InvalidationManagerTest is Test, OrderInvalidation {
 
     bytes4 internal constant NONCES_SLOT = bytes4(keccak256("angstrom-v1_0.unordered-nonces.slot"));
     uint256 private constant MAX_TWAP_INTERVAL = 0x1e187e0;
-    uint256 private constant MIN_TWAP_INTERVAL = 5;
+    uint256 private constant MIN_TWAP_INTERVAL = 12;
     uint256 private constant MAX_TWAP_TOTAL_PARTS = 0x604e60;
     uint256 private constant MAX_U32_VAL = type(uint32).max;
 

--- a/contracts/test/modules/OrderInvalidation.t.sol
+++ b/contracts/test/modules/OrderInvalidation.t.sol
@@ -10,10 +10,56 @@ contract InvalidationManagerTest is Test, OrderInvalidation {
     using Utils for *;
 
     bytes4 internal constant NONCES_SLOT = bytes4(keccak256("angstrom-v1_0.unordered-nonces.slot"));
+    uint256 private constant MAX_TWAP_INTERVAL = 0x1e187e0;
+    uint256 private constant MAX_TWAP_TOTAL_PARTS = 0x604e60;
 
     function test_fuzzing_revertsUponReuse(address owner, uint64 nonce) public {
         _invalidateNonce(owner.brutalize(), nonce.brutalize());
         vm.expectRevert(OrderInvalidation.NonceReuse.selector);
         _invalidateNonce(owner.brutalize(), nonce.brutalize());
+    }
+
+    function test_fuzzing_revertsUponTWAPNonceReuse(uint64 nonce) public {
+        this.invalidateTWAPNonce(nonce.brutalize());
+        vm.expectRevert(OrderInvalidation.TWAPNonceReuse.selector);
+        this.invalidateTWAPNonce(nonce.brutalize());
+    }
+
+    function test_fuzzing_revertsUponInvalidTWAPData(uint32 interval, uint32 tParts) public view {
+        interval = uint32(bound(uint256(interval), 1, MAX_TWAP_INTERVAL));
+        tParts = uint32(bound(uint256(tParts), 1, MAX_TWAP_TOTAL_PARTS));
+        _checkTWAPOrderData(interval.brutalizeU32(), tParts.brutalizeU32());
+    }
+
+    /// forge-config: default.allow_internal_expect_revert = true
+    function test_fuzzing_revertsUponPartsTWAPNonceReuse(
+        address owner,
+        uint64 nonce,
+        uint32 interval, 
+        uint32 tParts
+    ) public {
+        uint40 sTime = uint40(block.timestamp);
+        interval = uint32(bound(uint256(interval), 0, MAX_TWAP_INTERVAL));
+        tParts = uint32(bound(uint256(tParts), 0, 20));
+
+        for(uint256 i = tParts; i != 0; i--){
+            _invalidatePartTWAPNonceAndCheckDeadline(
+                owner.brutalize(), 
+                nonce.brutalize(), 
+                sTime.brutalizeU40(), 
+                interval.brutalizeU32(), 
+                tParts.brutalizeU32()
+            );
+            uint256 warpedTime = sTime + ((tParts-(i-1)) * interval);
+            vm.warp(warpedTime);
+        }
+        vm.expectRevert(OrderInvalidation.TWAPNonceReuse.selector);
+        _invalidatePartTWAPNonceAndCheckDeadline(
+            owner.brutalize(), 
+            nonce.brutalize(), 
+            sTime.brutalizeU40(), 
+            interval.brutalizeU32(), 
+            tParts.brutalizeU32()
+        );
     }
 }

--- a/contracts/test/types/TWAPOrderBuffer.t.sol
+++ b/contracts/test/types/TWAPOrderBuffer.t.sol
@@ -36,7 +36,8 @@ contract TWAPOrderBufferTest is BaseTest {
                 bytes8(order.nonce),
                 bytes5(order.startTime),
                 bytes4(order.totalParts),
-                bytes4(order.timeInterval)
+                bytes4(order.timeInterval),
+                bytes4(order.window)
             )
         );
     }
@@ -68,7 +69,7 @@ contract TWAPOrderBufferTest is BaseTest {
     }
 
     function ffiPythonEIP712Hash(TimeWeightedAveragePriceOrder memory order) internal returns (bytes32) {
-        string[] memory args = new string[](16);
+        string[] memory args = new string[](17);
         args[0] = "test/_reference/eip712.py";
         args[1] = "test/_reference/SignedTypes.sol:TimeWeightedAveragePriceOrder";
         uint256 i = 2;
@@ -90,6 +91,7 @@ contract TWAPOrderBufferTest is BaseTest {
         args[i++] = vm.toString(order.startTime);
         args[i++] = vm.toString(order.totalParts);
         args[i++] = vm.toString(order.timeInterval);
+        args[i++] = vm.toString(order.window);
         return bytes32(ffiPython(args));
     }
 }

--- a/contracts/test/types/TWAPOrderBuffer.t.sol
+++ b/contracts/test/types/TWAPOrderBuffer.t.sol
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {BaseTest} from "test/_helpers/BaseTest.sol";
+import {TWAPOrderBuffer, TWAPOrderBufferLib} from "src/types/TWAPOrderBuffer.sol";
+import {TimeWeightedAveragePriceOrder} from "test/_reference/OrderTypes.sol";
+import {TWAPOrderVariantMap} from "src/types/TWAPOrderVariantMap.sol";
+import {OrderVariant} from "test/_reference/OrderVariant.sol";
+import {CalldataReader, CalldataReaderLib} from "src/types/CalldataReader.sol";
+
+/// @author philogy <https://github.com/philogy>
+contract TWAPOrderBufferTest is BaseTest {
+    function setUp() public {}
+
+    function test_fuzzing_referenceEqBuffer_TWAPOrder(TimeWeightedAveragePriceOrder memory order)
+        public
+        view
+    {
+        assertEq(bufferHash(order), order.hash());
+    }
+
+
+    function test_ffi_fuzzing_bufferPythonEquivalence_TWAPOrder(
+        TimeWeightedAveragePriceOrder memory order
+    ) public {
+        assertEq(bufferHash(order), ffiPythonEIP712Hash(order));
+    }
+
+
+    function bufferHash(TimeWeightedAveragePriceOrder memory order) internal view returns (bytes32) {
+        return this._bufferHashTWAPOrder(
+            order,
+            bytes.concat(
+                bytes1(order.toVariantMap(false)),
+                bytes4(order.refId),
+                bytes8(order.nonce),
+                bytes5(order.startTime),
+                bytes4(order.totalParts),
+                bytes4(order.timeInterval)
+            )
+        );
+    }
+
+    function _bufferHashTWAPOrder(
+        TimeWeightedAveragePriceOrder memory order,
+        bytes calldata dataStart
+    ) external pure returns (bytes32) {
+        CalldataReader reader = CalldataReaderLib.from(dataStart);
+        TWAPOrderBuffer memory buffer;
+        TWAPOrderVariantMap varMap;
+        (reader, varMap) = buffer.init(reader);
+
+        buffer.exactIn = order.exactIn;
+        buffer.quantity = order.amount;
+        buffer.maxExtraFeeAsset0 = order.maxExtraFeeAsset0;
+        buffer.minPrice = order.minPrice;
+        buffer.useInternal = order.useInternal;
+        buffer.assetIn = order.assetIn;
+        buffer.assetOut = order.assetOut;
+        buffer.recipient = order.recipient;
+        buffer.hookDataHash = keccak256(
+            order.hook == address(0)
+                ? new bytes(0)
+                : bytes.concat(bytes20(order.hook), order.hookPayload)
+        );
+        buffer.readOrderValidation(reader);
+        return buffer.hash();
+    }
+
+    function ffiPythonEIP712Hash(TimeWeightedAveragePriceOrder memory order) internal returns (bytes32) {
+        string[] memory args = new string[](16);
+        args[0] = "test/_reference/eip712.py";
+        args[1] = "test/_reference/SignedTypes.sol:TimeWeightedAveragePriceOrder";
+        uint256 i = 2;
+        args[i++] = vm.toString(order.refId);
+        args[i++] = vm.toString(order.exactIn);
+        args[i++] = vm.toString(order.amount);
+        args[i++] = vm.toString(order.maxExtraFeeAsset0);
+        args[i++] = vm.toString(order.minPrice);
+        args[i++] = vm.toString(order.useInternal);
+        args[i++] = vm.toString(order.assetIn);
+        args[i++] = vm.toString(order.assetOut);
+        args[i++] = vm.toString(order.recipient);
+        args[i++] = vm.toString(
+            order.hook == address(0)
+                ? new bytes(0)
+                : bytes.concat(bytes20(order.hook), order.hookPayload)
+        );
+        args[i++] = vm.toString(order.nonce);
+        args[i++] = vm.toString(order.startTime);
+        args[i++] = vm.toString(order.totalParts);
+        args[i++] = vm.toString(order.timeInterval);
+        return bytes32(ffiPython(args));
+    }
+}


### PR DESCRIPTION
adds support for TWAP orders on Angstrom by allowing users to authorize/sign a single order that can be executed multiple times at fixed intervals.