### PR TITLE
add 30-100ms of jitter to PreProprosalWaitTrigger

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2984,6 +2984,7 @@ dependencies = [
  "matching-engine",
  "order-pool",
  "pade",
+ "rand 0.8.5",
  "rayon",
  "reth-metrics",
  "reth-primitives 1.2.1",

--- a/crates/consensus/Cargo.toml
+++ b/crates/consensus/Cargo.toml
@@ -35,6 +35,7 @@ alloy-rlp.workspace = true
 reth-tasks.workspace = true
 secp256k1.workspace = true
 itertools.workspace = true
+rand.workspace = true
 
 angstrom-types.workspace = true
 angstrom-utils.workspace = true

--- a/crates/consensus/src/rounds/preproposal_wait_trigger.rs
+++ b/crates/consensus/src/rounds/preproposal_wait_trigger.rs
@@ -5,6 +5,7 @@ use std::{
     time::{Duration, Instant}
 };
 
+use rand::Rng;
 use tokio::time::{Interval, interval};
 
 use crate::rounds::OrderStorage;
@@ -53,8 +54,11 @@ impl Clone for PreProposalWaitTrigger {
 
 impl PreProposalWaitTrigger {
     pub fn new(order_storage: Arc<OrderStorage>) -> Self {
+        let mut rng = rand::thread_rng();
+        let jitter = Duration::from_millis(rng.gen_range(30..=100));
+
         Self {
-            wait_duration: DEFAULT_DURATION,
+            wait_duration: DEFAULT_DURATION + jitter,
             order_storage,
             start_instant: Instant::now(),
             check_interval: interval(CHECK_INTERVAL)


### PR DESCRIPTION
https://linear.app/sorellalabs/issue/BACK-170/consensus-add-jitter-to-pre-proposal-to-help-avoid-timing-attacks