### PR TITLE
fix validation add checks for no amount set

### DIFF
--- a/crates/types/src/primitive/validation.rs
+++ b/crates/types/src/primitive/validation.rs
@@ -20,10 +20,12 @@ pub enum OrderValidationError {
     NotEnoughGas,
     #[error("duplicate order")]
     DuplicateOrder,
-    #[error("Not Valid At Block")]
+    #[error("not valid at block")]
     InvalidOrderAtBlock,
-    #[error("No Amount Specified")]
+    #[error("no amount specified")]
     NoAmountSpecified,
+    #[error("max gas for this order is greater than min amount")]
+    MaxGasGreaterThanMinAmount,
     #[error("unknown")]
     Unknown(String)
 }

--- a/crates/validation/src/order/state/mod.rs
+++ b/crates/validation/src/order/state/mod.rs
@@ -254,7 +254,7 @@ impl OrderValidation for EnsureMaxGasLessThanMinAmount {
         state: &mut OrderValidationState<O>
     ) -> Result<(), OrderValidationError> {
         if state.min_qty_in_t0() < state.order.max_gas_token_0() {
-            Err(OrderValidationError::InvalidPartialOrder)
+            Err(OrderValidationError::MaxGasGreaterThanMinAmount)
         } else {
             Ok(())
         }


### PR DESCRIPTION
https://linear.app/sorellalabs/issue/BACK-257/fix-validation-add-checks-for-no-amount-set