### PR TITLE
[BACK-263] Create Price->Partial->Volume strategy and make it default

### DIFF
--- a/crates/matching-engine/benches/delta_tps.rs
+++ b/crates/matching-engine/benches/delta_tps.rs
@@ -216,7 +216,8 @@ fn setup_inputs(
         tob_reward: U256::ZERO
     };
 
-    let book = OrderBook::new(pool_id, Some(amm), bids, asks, Some(SortStrategy::ByPriceByVolume));
+    let book =
+        OrderBook::new(pool_id, Some(amm), bids, asks, Some(SortStrategy::PricePartialVolume));
 
     (book, tob)
 }

--- a/crates/matching-engine/src/lib.rs
+++ b/crates/matching-engine/src/lib.rs
@@ -34,9 +34,5 @@ pub fn build_book(id: PoolId, amm: Option<PoolSnapshot>, orders: HashSet<BookOrd
     let (mut bids, mut asks): (Vec<BookOrder>, Vec<BookOrder>) =
         orders.into_iter().partition(|o| o.is_bid);
 
-    // assert bids decreasing and asks increasing
-    bids.sort_by_key(|b| std::cmp::Reverse(b.limit_price()));
-    asks.sort_by_key(|a| a.limit_price());
-
-    OrderBook::new(id, amm, bids, asks, Some(book::sort::SortStrategy::ByPriceByVolume))
+    OrderBook::new(id, amm, bids, asks, Some(book::sort::SortStrategy::PricePartialVolume))
 }

--- a/crates/types/src/orders/orderpool/mod.rs
+++ b/crates/types/src/orders/orderpool/mod.rs
@@ -64,6 +64,10 @@ impl PartialOrd for OrderPriorityData {
 }
 
 impl Ord for OrderPriorityData {
+    /// This implements the "default" sort which is to sort first by price, then
+    /// by volume, then gas, then gas_units
+    /// We might want to remove this given that our sorts are more complicated
+    /// than this
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
         self.price
             .cmp(&other.price)


### PR DESCRIPTION
Updated our strategies to include this new technique and made it the default for our DeltaMatcher.  We still do have the older "default" way to compare OrderPriority structures as our implementation for `Cmp` on that structure but that's probably just fine.

We might also in the future want to move this around so we're doing a whole `OrderBook<S>` where `S` is our strategy but that's only going to be worthwhile if we start to have several different strategies that we want to implement and distinguish between.