### PR TITLE
[BACK-284] Allow exact orders to be killed at UCP

### DIFF
--- a/crates/matching-engine/benches/delta_tps.rs
+++ b/crates/matching-engine/benches/delta_tps.rs
@@ -216,7 +216,8 @@ fn setup_inputs(
         tob_reward: U256::ZERO
     };
 
-    let book = OrderBook::new(pool_id, Some(amm), bids, asks, Some(SortStrategy::ByPriceByVolume));
+    let book =
+        OrderBook::new(pool_id, Some(amm), bids, asks, Some(SortStrategy::PricePartialVolume));
 
     (book, tob)
 }

--- a/crates/matching-engine/src/lib.rs
+++ b/crates/matching-engine/src/lib.rs
@@ -34,9 +34,5 @@ pub fn build_book(id: PoolId, amm: Option<PoolSnapshot>, orders: HashSet<BookOrd
     let (mut bids, mut asks): (Vec<BookOrder>, Vec<BookOrder>) =
         orders.into_iter().partition(|o| o.is_bid);
 
-    // assert bids decreasing and asks increasing
-    bids.sort_by_key(|b| std::cmp::Reverse(b.limit_price()));
-    asks.sort_by_key(|a| a.limit_price());
-
-    OrderBook::new(id, amm, bids, asks, Some(book::sort::SortStrategy::ByPriceByVolume))
+    OrderBook::new(id, amm, bids, asks, Some(book::sort::SortStrategy::PricePartialVolume))
 }

--- a/crates/matching-engine/src/lib.rs
+++ b/crates/matching-engine/src/lib.rs
@@ -31,8 +31,7 @@ pub trait MatchingEngineHandle: Send + Sync + Clone + Unpin + 'static {
 }
 
 pub fn build_book(id: PoolId, amm: Option<PoolSnapshot>, orders: HashSet<BookOrder>) -> OrderBook {
-    let (bids, asks): (Vec<BookOrder>, Vec<BookOrder>) =
-        orders.into_iter().partition(|o| o.is_bid);
+    let (bids, asks): (Vec<BookOrder>, Vec<BookOrder>) = orders.into_iter().partition(|o| o.is_bid);
 
     OrderBook::new(id, amm, bids, asks, Some(book::sort::SortStrategy::PricePartialVolume))
 }

--- a/crates/matching-engine/src/lib.rs
+++ b/crates/matching-engine/src/lib.rs
@@ -31,7 +31,7 @@ pub trait MatchingEngineHandle: Send + Sync + Clone + Unpin + 'static {
 }
 
 pub fn build_book(id: PoolId, amm: Option<PoolSnapshot>, orders: HashSet<BookOrder>) -> OrderBook {
-    let (mut bids, mut asks): (Vec<BookOrder>, Vec<BookOrder>) =
+    let (bids, asks): (Vec<BookOrder>, Vec<BookOrder>) =
         orders.into_iter().partition(|o| o.is_bid);
 
     OrderBook::new(id, amm, bids, asks, Some(book::sort::SortStrategy::PricePartialVolume))

--- a/crates/types/src/orders/orderpool/mod.rs
+++ b/crates/types/src/orders/orderpool/mod.rs
@@ -64,6 +64,10 @@ impl PartialOrd for OrderPriorityData {
 }
 
 impl Ord for OrderPriorityData {
+    /// This implements the "default" sort which is to sort first by price, then
+    /// by volume, then gas, then gas_units
+    /// We might want to remove this given that our sorts are more complicated
+    /// than this
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
         self.price
             .cmp(&other.price)

--- a/crates/types/src/sol_bindings/ray.rs
+++ b/crates/types/src/sol_bindings/ray.rs
@@ -43,6 +43,18 @@ impl Sum for Ray {
     }
 }
 
+impl PartialEq<U256> for Ray {
+    fn eq(&self, other: &U256) -> bool {
+        self.0.eq(other)
+    }
+}
+
+impl PartialOrd<U256> for Ray {
+    fn partial_cmp(&self, other: &U256) -> Option<std::cmp::Ordering> {
+        self.0.partial_cmp(other)
+    }
+}
+
 impl From<Ray> for Natural {
     fn from(value: Ray) -> Self {
         Natural::from_limbs_asc(value.0.as_limbs())


### PR DESCRIPTION
As per our discussion, this will allow exact orders at UCP to be killed in order to permit the book to be solved.  This works in the following way

- Each time we evaluate a price, we check to see if there are a set of exact orders at that price that could be killed in order to bring the. book into a solveable state
- If we are not yet at the end of our iteration through the book, we ignore this information and proceed as usual.  Basically we consider moving the price to exclude orders to be our way of "killing" the orders that are preventing us from reaching a solution.
- At the point at which we are down to our last 2 iterations, we start allowing orders to be killed.  This is because our last iteration might actually be one step OFF the critical price with a major order, so we have to check the last two.
- If we do find orders that can be killed to bring the book to a solveable state, we kill them and reset our solution (as removing these orders from consideration might result in a very different solution)