### PR TITLE
chore: add justfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
 # Angstrom
+
+## Prerequisites
+- [Rust](https://rustup.rs/)
+- [just](https://github.com/casey/just#installation)

--- a/justfile
+++ b/justfile
@@ -1,6 +1,8 @@
 default:
     @just --list
 
+ci: check-format check-clippy test test-integration
+
 check: check-format check-clippy test
 
 fix: fix-format fix-clippy

--- a/justfile
+++ b/justfile
@@ -6,7 +6,7 @@ check: check-format check-clippy test
 fix: fix-format fix-clippy
 
 test:
-    cargo test --workspace --all-features
+    cargo nextest run --workspace --all-targets
 
 check-format:
     cargo fmt --all -- --check

--- a/justfile
+++ b/justfile
@@ -1,0 +1,28 @@
+default:
+    @just --list
+
+check: check-format check-clippy test
+
+fix: fix-format fix-clippy
+
+test:
+    cargo test --workspace --all-features
+
+check-format:
+    cargo fmt --all -- --check
+
+fix-format:
+    cargo fmt --all
+
+check-clippy:
+    cargo clippy --all-targets -- -D warnings
+
+fix-clippy:
+    cargo clippy --all-targets --fix --allow-dirty --allow-staged
+
+build:
+    cargo build --release
+
+clean:
+    cargo clean
+

--- a/justfile
+++ b/justfile
@@ -6,7 +6,10 @@ check: check-format check-clippy test
 fix: fix-format fix-clippy
 
 test:
-    cargo nextest run --workspace --all-targets
+    cargo nextest run --workspace --lib
+
+test-integration:
+    cargo nextest run --workspace --tests
 
 check-format:
     cargo fmt --all -- --check


### PR DESCRIPTION
Make it a bit more ergonomic to work.
`just ci` instead of running all cmds individually.
No contract commands yet, but can be added.