### PR TITLE
chore: tests should respect RUST_LOG=off

### DIFF
--- a/crates/matching-engine/tests/bundle.rs
+++ b/crates/matching-engine/tests/bundle.rs
@@ -12,11 +12,11 @@ use booklib::{
     AMM_SIDE_BOOK, DEBT_WRONG_SIDE, DELTA_BOOK_TEST, GOOD_BOOK, MATH_ZERO, WEIRD_BOOK,
     ZERO_ASK_BOOK
 };
-use tracing::Level;
+use tracing_subscriber::EnvFilter;
 
 pub fn with_tracing<T>(f: impl FnOnce() -> T) -> T {
     let subscriber = tracing_subscriber::fmt()
-        .with_max_level(Level::TRACE)
+        .with_env_filter(EnvFilter::from_default_env())
         .with_line_number(true)
         .with_file(true)
         .finish();

--- a/crates/matching-engine/tests/matching.rs
+++ b/crates/matching-engine/tests/matching.rs
@@ -12,11 +12,11 @@ use matching_engine::{
     matcher::delta::{DeltaMatcher, DeltaMatcherToB}
 };
 use testing_tools::type_generator::orders::UserOrderBuilder;
-use tracing::Level;
+use tracing_subscriber::EnvFilter;
 
 pub fn with_tracing<T>(f: impl FnOnce() -> T) -> T {
     let subscriber = tracing_subscriber::fmt()
-        .with_max_level(Level::TRACE)
+        .with_env_filter(EnvFilter::from_default_env())
         .with_line_number(true)
         .with_file(true)
         .finish();

--- a/crates/types/tests/angstrom.rs
+++ b/crates/types/tests/angstrom.rs
@@ -9,11 +9,11 @@ use angstrom_types::{
 };
 use base64::Engine;
 use solutionlib::ANOTHER_BAD;
-use tracing::Level;
+use tracing_subscriber::EnvFilter;
 
 pub fn with_tracing<T>(f: impl FnOnce() -> T) -> T {
     let subscriber = tracing_subscriber::fmt()
-        .with_max_level(Level::TRACE)
+        .with_env_filter(EnvFilter::from_default_env())
         .with_line_number(true)
         .with_file(true)
         .finish();


### PR DESCRIPTION
Running tests I sometimes wanna disable the logging and it's currently not possible since log level `TRACE` is hardcoded.
With this change it's possible to disable logs with `RUST_LOG=off cargo test`.

It also changes the default log level from `TRACE` to `INFO`. I think that's reasonable, but feel free to let me know if it's not and I'll revert this change.