### PR TITLE
chore: use nextest in ci

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -129,8 +129,10 @@ jobs:
           key: cargo-test
           cache-on-failure: true
 
-      - name: cargo test --workspace
-        run: cargo test --workspace
+      - uses: taiki-e/install-action@nextest
+
+      - name: Run tests
+        run: cargo nextest run --retries 3 --no-tests=warn
 
   contracts:
     name: forge fmt && forge test


### PR DESCRIPTION
Currently tests times out in CI:
> Check Rust / cargo test (pull_request) Cancelled after 25m
https://github.com/SorellaLabs/angstrom/actions/runs/16491770846/job/46627941381

Use nextest to run tests faster in CI.