### PR TITLE
chore: improve CI speed

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -30,31 +30,6 @@ jobs:
       - name: cargo +nightly fmt
         run: cargo +nightly fmt --all -- --check
 
-  cargo-check:
-    name: cargo check
-    runs-on: ubuntu-latest
-    timeout-minutes: 25
-    steps:
-      - name: Check-Out
-        uses: actions/checkout@v4
-        with:
-          submodules: recursive
-
-      - name: Install Foundry
-        uses: foundry-rs/foundry-toolchain@v1
-        with:
-          version: stable
-          cache: true
-
-      - uses: Swatinem/rust-cache@v2
-        with:
-          cache-on-failure: true
-          shared-key: "rust-cache-v1"
-          save-if: true
-
-      - name: cargo check --workspace --all-features
-        run: cargo check --workspace --all-features
-
   cargo-clippy:
     name: cargo clippy
     runs-on: ubuntu-latest
@@ -79,41 +54,6 @@ jobs:
 
       - name: cargo clippy --workspace --all-features
         run: cargo clippy --workspace --all-features
-
-  cargo-fix:
-    name: cargo fix
-    runs-on: ubuntu-latest
-    timeout-minutes: 25
-    steps:
-      - name: Check-Out
-        uses: actions/checkout@v4
-        with:
-          submodules: recursive
-
-      - name: Install Foundry
-        uses: foundry-rs/foundry-toolchain@v1
-        with:
-          version: stable
-          cache: true
-
-      - uses: Swatinem/rust-cache@v2
-        with:
-          cache-on-failure: true
-          shared-key: "rust-cache-v1"
-          save-if: true
-
-      - name: cargo fix --workspace --all-features
-        run: |
-          # Run cargo fix on the project
-          cargo fix --workspace --all-features
-
-          # Check for local git changes
-          if ! git diff --exit-code; then
-              echo "There are local changes after running 'cargo fix --workspace --all-features' ❌"
-              exit 1
-          else
-              echo "No changes detected after running 'cargo fix --workspace --all-features' ✅"
-          fi
 
   cargo-test-unit:
     name: cargo test (unit)

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -80,7 +80,7 @@ jobs:
       - uses: taiki-e/install-action@nextest
 
       - name: Run unit tests
-        run: cargo nextest run --workspace --exclude testnet --retries 3 --no-tests=warn --profile debug-fast
+        run: cargo nextest run --workspace --exclude testnet --retries 3 --no-tests=warn --cargo-profile debug-fast
 
   cargo-test-integration:
     name: cargo test (integration)
@@ -107,7 +107,7 @@ jobs:
       - uses: taiki-e/install-action@nextest
 
       - name: Run integration tests
-        run: cargo nextest run --package testnet --retries 1 --no-tests=warn --profile debug-fast
+        run: cargo nextest run --package testnet --retries 1 --no-tests=warn --cargo-profile debug-fast
 
   contracts:
     name: forge fmt && forge test

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -27,7 +27,7 @@ jobs:
           rustup toolchain install nightly
           rustup component add --toolchain nightly-x86_64-unknown-linux-gnu rustfmt
 
-      - name: cargo +nightly fmt
+      - name: Run formatting
         run: cargo +nightly fmt --all -- --check
 
   cargo-clippy:
@@ -52,8 +52,8 @@ jobs:
           shared-key: "rust-cache-v1"
           save-if: true
 
-      - name: cargo clippy --workspace --all-features
-        run: cargo clippy --workspace --all-features
+      - name: Run Clippy
+        run: cargo clippy --workspace --all-features --profile debug-fast
 
   cargo-test-unit:
     name: cargo test (unit)
@@ -80,7 +80,7 @@ jobs:
       - uses: taiki-e/install-action@nextest
 
       - name: Run unit tests
-        run: cargo nextest run --workspace --exclude testnet --retries 3 --no-tests=warn
+        run: cargo nextest run --workspace --exclude testnet --retries 3 --no-tests=warn --profile debug-fast
 
   cargo-test-integration:
     name: cargo test (integration)
@@ -107,7 +107,7 @@ jobs:
       - uses: taiki-e/install-action@nextest
 
       - name: Run integration tests
-        run: cargo nextest run --package testnet --retries 1 --no-tests=warn
+        run: cargo nextest run --package testnet --retries 1 --no-tests=warn --profile debug-fast
 
   contracts:
     name: forge fmt && forge test


### PR DESCRIPTION
Clippy is superset of check, so don't need to run both. Cargo fix is something to run locally and commit, in CI the result is not used for anything AFAIK.