### PR TITLE
fix: handle shutdown more gracefully

### DIFF
--- a/crates/amm-quoter/src/lib.rs
+++ b/crates/amm-quoter/src/lib.rs
@@ -223,7 +223,8 @@ impl<BlockSync: BlockSyncConsumer> QuoterManager<BlockSync> {
                     tick
                 };
 
-                tx.send(update).unwrap()
+                // Receiver may have been dropped during shutdown; ignore send errors.
+                let _ = tx.send(update);
             });
 
             self.pending_tasks.push(rx.map_err(Into::into).boxed())

--- a/crates/angstrom-net/src/session/strom/regular.rs
+++ b/crates/angstrom-net/src/session/strom/regular.rs
@@ -42,7 +42,8 @@ impl RegularProcessing {
             let Some(next) = self.manager_buffer.pop_front() else {
                 return;
             };
-            self.to_session_manager.send_item(next).unwrap()
+            // If the manager is dropped (e.g., during shutdown), ignore send errors.
+            let _ = self.to_session_manager.send_item(next);
         }
     }
 }

--- a/crates/angstrom-net/src/session/strom/startup.rs
+++ b/crates/angstrom-net/src/session/strom/startup.rs
@@ -69,9 +69,10 @@ impl<S: AngstromMetaSigner> StromStartup<S> {
         match self.to_session_manager.poll_reserve(cx) {
             Poll::Ready(Ok(())) => {
                 let handle = self.handle.take().unwrap();
-                self.to_session_manager
-                    .send_item(StromSessionMessage::Established { handle })
-                    .unwrap();
+                // Manager may be dropped during shutdown; ignore send errors.
+                let _ = self
+                    .to_session_manager
+                    .send_item(StromSessionMessage::Established { handle });
                 return true;
             }
             Poll::Ready(Err(_)) => {


### PR DESCRIPTION
Try to get rid of the panics still present in integration tests
https://github.com/SorellaLabs/angstrom/actions/runs/17204741850/job/48802765688