### PR TITLE
chore: give each CI job cache key

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -50,8 +50,8 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
         with:
+          key: cargo-clippy-${{ runner.os }}
           cache-on-failure: true
-          shared-key: "rust-cache-v1"
           save-if: true
 
       - name: Run Clippy
@@ -75,8 +75,8 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
         with:
+          key: cargo-test-unit-${{ runner.os }}
           cache-on-failure: true
-          shared-key: "rust-cache-v1"
           save-if: true
 
       - uses: taiki-e/install-action@nextest
@@ -102,8 +102,8 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
         with:
+          key: cargo-test-integration-${{ runner.os }}
           cache-on-failure: true
-          shared-key: "rust-cache-v1"
           save-if: true
 
       - uses: taiki-e/install-action@nextest

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -2,7 +2,7 @@ name: Check Rust
 on:
   pull_request:
 
-# stop in-progress on new push
+# Stop in-progress on new push
 concurrency:
   group: ${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
Reusing same key doesn't work because the jobs produce different artifacts.

`cargo clippy` in 2m instead of 6m
`cargo test (unit)` in 4m instead of 9m

I think integration is still slow because it is always cancelled and haven't cached something yet