### PR TITLE
chore: run ci on main branch

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,6 +1,9 @@
 name: Check Rust
 on:
   pull_request:
+  push:
+    branches:
+      - main
 
 # Stop in-progress on new push
 concurrency:


### PR DESCRIPTION
Currently you have to look at the commit history to see if current main is green