### PR TITLE
feat: more introspection

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -123,6 +123,8 @@ jobs:
     name: forge fmt && forge test
     runs-on: ubuntu-latest
     timeout-minutes: 25
+    env:
+      ETH_RPC_URL: ${{ secrets.ETH_RPC_URL }}
     steps:
       - uses: actions/checkout@v4
         with:

--- a/contracts/foundry.toml
+++ b/contracts/foundry.toml
@@ -54,3 +54,6 @@ optimizer = true
 ast = true
 src = "../crates/uniswap-v4/src/uniswap/loaders"
 libs = ["lib"]
+
+[rpc_endpoints]
+mainnet = "${ETH_RPC_URL}"

--- a/contracts/script/AngstromInspector.s.sol
+++ b/contracts/script/AngstromInspector.s.sol
@@ -19,7 +19,7 @@ contract AngstromInspectorScript is Script {
             new AngstromInspector(IAngstromAuth(angstrom), IPoolManager(uniswap));
 
         vm.stopBroadcast();
-        console.log("[INFO] deployed apdater to %s", address(inspector));
+        console.log("[INFO] deployed AngstromInspector to %s", address(inspector));
     }
 
     function isChain(string memory name) internal returns (bool) {

--- a/contracts/script/AngstromInspector.s.sol
+++ b/contracts/script/AngstromInspector.s.sol
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {Script} from "forge-std/Script.sol";
+import {console} from "forge-std/console.sol";
+
+import {IAngstromAuth} from "src/interfaces/IAngstromAuth.sol";
+import {IPoolManager} from "src/interfaces/IUniV4.sol";
+import {AngstromInspector} from "src/periphery/AngstromInspector.sol";
+
+/// @author crypto-banker <https://github.com/crypto-banker>
+contract AngstromInspectorScript is Script {
+    function run() public {
+        address uniswap = uniswapOnCurrentChain();
+        address angstrom = angstromOnCurrentChain();
+
+        vm.startBroadcast();
+        AngstromInspector inspector =
+            new AngstromInspector(IAngstromAuth(angstrom), IPoolManager(uniswap));
+
+        vm.stopBroadcast();
+        console.log("[INFO] deployed apdater to %s", address(inspector));
+    }
+
+    function isChain(string memory name) internal returns (bool) {
+        return getChain(name).chainId == block.chainid;
+    }
+
+    function uniswapOnCurrentChain() internal returns (address) {
+        if (isChain("sepolia")) {
+            return 0xE03A1074c86CFeDd5C142C4F04F1a1536e203543;
+        }
+        if (isChain("mainnet")) {
+            return 0x000000000004444c5dc75cB358380D2e3dE08A90;
+        }
+        revert(string.concat("Unsupported chain: ", getChain(block.chainid).name));
+    }
+
+    function angstromOnCurrentChain() internal returns (address) {
+        if (isChain("sepolia")) {
+            return 0x9051085355BA7e36177e0a1c4082cb88C270ba90;
+        }
+        if (isChain("mainnet")) {
+            return 0x0000000aa232009084Bd71A5797d089AA4Edfad4;
+        }
+        revert(string.concat("Unsupported chain: ", getChain(block.chainid).name));
+    }
+}

--- a/contracts/src/modules/Settlement.sol
+++ b/contracts/src/modules/Settlement.sol
@@ -14,6 +14,7 @@ import {SafeTransferLib} from "solady/src/utils/SafeTransferLib.sol";
 abstract contract Settlement is UniConsumer {
     using SafeTransferLib for address;
 
+    // known typo; cannot correct post-deployment
     error BundlDeltaUnresolved(address asset);
 
     DeltaTracker internal bundleDeltas;

--- a/contracts/src/periphery/AngstromInspector.sol
+++ b/contracts/src/periphery/AngstromInspector.sol
@@ -79,10 +79,9 @@ contract AngstromInspector {
         PoolKey memory key,
         int24 tickLower,
         int24 tickUpper,
-        bytes32 salt,
-        IPoolManager uniV4
+        bytes32 salt
     ) public view returns (uint256, uint256) {
-        return angstrom.totalPendingRewards(account, key, tickLower, tickUpper, salt, uniV4);
+        return angstrom.totalPendingRewards(account, key, tickLower, tickUpper, salt, uniswapPoolManager);
     }
 
     /// @notice Returns the pending rewards held by the Angstrom hook for the position defined
@@ -93,10 +92,9 @@ contract AngstromInspector {
         PoolKey memory key,
         int24 tickLower,
         int24 tickUpper,
-        bytes32 salt,
-        IPoolManager uniV4
+        bytes32 salt
     ) public view returns (uint256) {
-        return angstrom.pendingRewards(account, key, tickLower, tickUpper, salt, uniV4);
+        return angstrom.pendingRewards(account, key, tickLower, tickUpper, salt, uniswapPoolManager);
     }
 
     function uniswapPendingRewards(
@@ -104,9 +102,8 @@ contract AngstromInspector {
         PoolKey memory key,
         int24 tickLower,
         int24 tickUpper,
-        bytes32 salt,
-        IPoolManager uniV4
+        bytes32 salt
     ) public view returns (uint256, uint256) {
-        return AngstromView.uniswapPendingRewards(account, key, tickLower, tickUpper, salt, uniV4);
+        return AngstromView.uniswapPendingRewards(account, key, tickLower, tickUpper, salt, uniswapPoolManager);
     }
 }

--- a/contracts/src/periphery/AngstromInspector.sol
+++ b/contracts/src/periphery/AngstromInspector.sol
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {PoolId, PoolIdLibrary} from "v4-core/src/types/PoolId.sol";
+import {PoolKey} from "v4-core/src/types/PoolKey.sol";
+
+import {IPoolManager} from "../interfaces/IUniV4.sol";
+import {IAngstromAuth} from "../interfaces/IAngstromAuth.sol";
+import {PoolConfigStore} from "../libraries/PoolConfigStore.sol";
+import {StoreKey} from "../libraries/PoolConfigStore.sol";
+import {X128MathLib} from "../libraries/X128MathLib.sol";
+import {Positions, Position} from "../types/Positions.sol";
+import {StateLibrary} from "v4-core/src/libraries/StateLibrary.sol";
+import {AngstromView} from "./AngstromView.sol";
+
+/// @notice Wrapper of `AngstromView` library, exposing the library functions as public functions.
+/// @dev You can call this contract to query various aspects of Angstrom state. For any state not
+/// covered by this library, you can use Angstrom's extsload function.
+contract AngstromInspector {
+    using AngstromView for IAngstromAuth;
+
+    IAngstromAuth public immutable angstrom;
+    IPoolManager public immutable uniswapPoolManager;
+
+    constructor(IAngstromAuth _angstrom, IPoolManager _uniswapPoolManager) {
+        angstrom = _angstrom;
+        uniswapPoolManager = _uniswapPoolManager;
+    }
+
+    function controller() public view returns (address) {
+        return angstrom.controller();
+    }
+
+    function lastBlockUpdated() public view returns (uint64) {
+        return angstrom.lastBlockUpdated();
+    }
+
+    function configStore() public view returns (PoolConfigStore addr) {
+        return angstrom.configStore();
+    }
+
+    function unlockedFee(StoreKey key) public view returns (uint24 fee, uint24 protocolFee) {
+        return angstrom.unlockedFee(key);
+    }
+
+    function balanceOf(address asset, address owner) public view returns (uint256) {
+        return angstrom.balanceOf(asset, owner);
+    }
+
+    /// @notice Returns poolRewards[id].globalGrowth
+    function poolRewardsGlobalGrowth(PoolId id) public view returns (uint256) {
+        return angstrom.poolRewardsGlobalGrowth(id);
+    }
+
+    /// @notice Returns poolRewards[id].rewardGrowthOutside[tick]
+    function poolRewardsGrowthOutside(PoolId id, uint24 tick) public view returns (uint256) {
+        return angstrom.poolRewardsGrowthOutside(id, tick);
+    }
+
+    /// @notice Returns the rewards growth inside of `lowerTick` and `upperTick`, given the `currentTick`,
+    /// for the pool identified by `id`
+    function getGrowthInside(PoolId id, int24 currentTick, int24 lowerTick, int24 upperTick)
+        public
+        view
+        returns (uint256 growthInside)
+    {
+        return angstrom.getGrowthInside(id, currentTick, lowerTick, upperTick);
+    }
+
+    /// @notice Returns positions[id][uniPositionKey].lastGrowthInside
+    function getLastGrowthInside(PoolId id, bytes32 uniPositionKey) public view returns (uint256) {
+        return angstrom.getLastGrowthInside(id, uniPositionKey);
+    }
+
+    /// @notice Returns the total pending rewards of the position defined  by the `(account, key, tickLower, tickUpper, salt)` tuple.
+    /// @dev Sums the return values of `pendingRewards` and `uniswapPendingRewards`.
+    function totalPendingRewards(
+        address account,
+        PoolKey memory key,
+        int24 tickLower,
+        int24 tickUpper,
+        bytes32 salt,
+        IPoolManager uniV4
+    ) public view returns (uint256, uint256) {
+        return angstrom.totalPendingRewards(account, key, tickLower, tickUpper, salt, uniV4);
+    }
+
+    /// @notice Returns the pending rewards held by the Angstrom hook for the position defined
+    /// by the `(account, key, tickLower, tickUpper, salt)` tuple.
+    /// @dev Rewards from Angstrom are always in the Currency0 of the pair.
+    function pendingRewards(
+        address account,
+        PoolKey memory key,
+        int24 tickLower,
+        int24 tickUpper,
+        bytes32 salt,
+        IPoolManager uniV4
+    ) public view returns (uint256) {
+        return angstrom.pendingRewards(account, key, tickLower, tickUpper, salt, uniV4);
+    }
+
+    function uniswapPendingRewards(
+        address account,
+        PoolKey memory key,
+        int24 tickLower,
+        int24 tickUpper,
+        bytes32 salt,
+        IPoolManager uniV4
+    ) public view returns (uint256, uint256) {
+        return AngstromView.uniswapPendingRewards(account, key, tickLower, tickUpper, salt, uniV4);
+    }
+}

--- a/contracts/src/periphery/AngstromView.sol
+++ b/contracts/src/periphery/AngstromView.sol
@@ -1,9 +1,18 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
+import {PoolId, PoolIdLibrary} from "v4-core/src/types/PoolId.sol";
+import {PoolKey} from "v4-core/src/types/PoolKey.sol";
+
+import {IPoolManager, IUniV4} from "../interfaces/IUniV4.sol";
 import {IAngstromAuth} from "../interfaces/IAngstromAuth.sol";
 import {PoolConfigStore} from "../libraries/PoolConfigStore.sol";
 import {StoreKey} from "../libraries/PoolConfigStore.sol";
+import {X128MathLib} from "../libraries/X128MathLib.sol";
+import {Positions, Position} from "../types/Positions.sol";
+
+using IUniV4 for IPoolManager;
+using PoolIdLibrary for PoolId;
 
 /// @author philogy <https://github.com/philogy>
 library AngstromView {
@@ -18,6 +27,12 @@ library AngstromView {
     uint256 constant STORE_BIT_OFFSET = 64;
 
     uint256 constant BALANCES_SLOT = 5;
+
+    uint256 constant POSITIONS_SLOT = 6;
+
+    uint256 constant POOL_REWARDS_SLOT = 7;
+
+    uint256 constant REWARD_GROWTH_SIZE = 16777216;
 
     function controller(IAngstromAuth self) internal view returns (address) {
         return address(uint160(self.extsload(CONTROLLER_SLOT)));
@@ -51,5 +66,85 @@ library AngstromView {
         bytes32 assetMapSlot = keccak256(abi.encode(asset, BALANCES_SLOT));
         bytes32 ownerBalanceSlot = keccak256(abi.encode(owner, assetMapSlot));
         return self.extsload(uint256(ownerBalanceSlot));
+    }
+
+    /// @notice Returns poolRewards[id].globalGrowth
+    function poolRewardsGlobalGrowth(IAngstromAuth self, PoolId id) internal view returns (uint256) {
+        uint256 rewardsMapSlot =
+            uint256(keccak256(abi.encode(id, POOL_REWARDS_SLOT))) + REWARD_GROWTH_SIZE;
+        return self.extsload(rewardsMapSlot);
+    }
+
+    /// @notice Returns poolRewards[id].rewardGrowthOutside[tick]
+    function poolRewardsGrowthOutside(IAngstromAuth self, PoolId id, uint24 tick)
+        internal
+        view
+        returns (uint256)
+    {
+        uint256 rewardsMapSlot =
+            uint256(keccak256(abi.encode(id, POOL_REWARDS_SLOT))) + uint256(tick);
+        return self.extsload(rewardsMapSlot);
+    }
+
+    /// @notice Returns the rewards growth inside of `lowerTick` and `upperTick`, given the `currentTick`,
+    /// for the pool identified by `id`
+    function getGrowthInside(
+        IAngstromAuth self,
+        PoolId id,
+        int24 currentTick,
+        int24 lowerTick,
+        int24 upperTick
+    ) internal view returns (uint256 growthInside) {
+        unchecked {
+            uint256 lowerTickGrowth = poolRewardsGrowthOutside(self, id, uint24(lowerTick));
+            uint256 upperTickGrowth = poolRewardsGrowthOutside(self, id, uint24(upperTick));
+
+            if (currentTick < lowerTick) {
+                return lowerTickGrowth - upperTickGrowth;
+            }
+            if (upperTick <= currentTick) {
+                return upperTickGrowth - lowerTickGrowth;
+            }
+
+            return poolRewardsGlobalGrowth(self, id) - lowerTickGrowth - upperTickGrowth;
+        }
+    }
+
+    /// @notice Returns positions[id][uniPositionKey].lastGrowthInside
+    function getLastGrowthInside(IAngstromAuth self, PoolId id, bytes32 uniPositionKey)
+        internal
+        view
+        returns (uint256)
+    {
+        bytes32 positionKeyMapSlot = keccak256(abi.encode(id, POSITIONS_SLOT));
+        bytes32 positionLastGrowthInsideSlot =
+            keccak256(abi.encode(uniPositionKey, positionKeyMapSlot));
+        return self.extsload(uint256(positionLastGrowthInsideSlot));
+    }
+
+    /// @notice Returns the pending rewards held by the Angstrom hook for the position defined
+    /// by the `(account, key, tickLower, tickUpper, salt)` tuple.
+    function pendingRewards(
+        IAngstromAuth self,
+        address account,
+        PoolKey memory key,
+        int24 tickLower,
+        int24 tickUpper,
+        bytes32 salt,
+        IPoolManager uniV4
+    ) internal view returns (uint256) {
+        unchecked {
+            PoolId id = key.toId();
+            bytes32 uniPositionKey =
+                keccak256(abi.encodePacked(account, tickLower, tickUpper, salt));
+            int24 currentTick = uniV4.getSlot0(id).tick();
+            uint256 growthInside = getGrowthInside(self, id, currentTick, tickLower, tickUpper);
+            uint256 lastGrowthInside = getLastGrowthInside(self, id, uniPositionKey);
+            uint128 positionTotalLiquidity = uniV4.getPositionLiquidity(id, uniPositionKey);
+            uint256 rewards =
+                X128MathLib.fullMulX128(growthInside - lastGrowthInside, positionTotalLiquidity);
+
+            return rewards;
+        }
     }
 }

--- a/contracts/src/periphery/AngstromView.sol
+++ b/contracts/src/periphery/AngstromView.sol
@@ -15,6 +15,7 @@ import {StateLibrary} from "v4-core/src/libraries/StateLibrary.sol";
 using PoolIdLibrary for PoolId;
 
 /// @author philogy <https://github.com/philogy>
+/// @author crypto-banker <https://github.com/crypto-banker>
 library AngstromView {
     using StateLibrary for IPoolManager;
 

--- a/contracts/src/periphery/AngstromView.sol
+++ b/contracts/src/periphery/AngstromView.sol
@@ -69,9 +69,13 @@ library AngstromView {
     }
 
     /// @notice Returns poolRewards[id].globalGrowth
-    function poolRewardsGlobalGrowth(IAngstromAuth self, PoolId id) internal view returns (uint256) {
-        uint256 rewardsMapSlot =
-            uint256(keccak256(abi.encode(id, POOL_REWARDS_SLOT))) + REWARD_GROWTH_SIZE;
+    function poolRewardsGlobalGrowth(IAngstromAuth self, PoolId id)
+        internal
+        view
+        returns (uint256)
+    {
+        uint256 rewardsMapSlot = uint256(keccak256(abi.encode(id, POOL_REWARDS_SLOT)))
+        + REWARD_GROWTH_SIZE;
         return self.extsload(rewardsMapSlot);
     }
 

--- a/contracts/src/periphery/AngstromView.sol
+++ b/contracts/src/periphery/AngstromView.sol
@@ -12,8 +12,6 @@ import {X128MathLib} from "../libraries/X128MathLib.sol";
 import {Positions, Position} from "../types/Positions.sol";
 import {StateLibrary} from "v4-core/src/libraries/StateLibrary.sol";
 
-using PoolIdLibrary for PoolId;
-
 /// @author philogy <https://github.com/philogy>
 /// @author crypto-banker <https://github.com/crypto-banker>
 library AngstromView {

--- a/contracts/src/periphery/AngstromView.sol
+++ b/contracts/src/periphery/AngstromView.sol
@@ -128,6 +128,24 @@ library AngstromView {
         return self.extsload(uint256(positionLastGrowthInsideSlot));
     }
 
+    /// @notice Returns the total pending rewards of the position defined  by the `(account, key, tickLower, tickUpper, salt)` tuple.
+    /// @dev Sums the return values of `pendingRewards` and `uniswapPendingRewards`.
+    function totalPendingRewards(
+        IAngstromAuth self,
+        address account,
+        PoolKey memory key,
+        int24 tickLower,
+        int24 tickUpper,
+        bytes32 salt,
+        IPoolManager uniV4
+    ) internal view returns (uint256, uint256) {
+        (uint256 rewardsCurrency0, uint256 rewardsCurrency1) =
+            uniswapPendingRewards(account, key, tickLower, tickUpper, salt, uniV4);
+        uint256 angstromRewards =
+            pendingRewards(self, account, key, tickLower, tickUpper, salt, uniV4);
+        return (rewardsCurrency0 + angstromRewards, rewardsCurrency1);
+    }
+
     /// @notice Returns the pending rewards held by the Angstrom hook for the position defined
     /// by the `(account, key, tickLower, tickUpper, salt)` tuple.
     /// @dev Rewards from Angstrom are always in the Currency0 of the pair.
@@ -144,7 +162,7 @@ library AngstromView {
             PoolId id = key.toId();
             bytes32 uniPositionKey =
                 keccak256(abi.encodePacked(account, tickLower, tickUpper, salt));
-            (, int24 currentTick, , ) = uniV4.getSlot0(id);
+            (, int24 currentTick,,) = uniV4.getSlot0(id);
             uint256 growthInside = getGrowthInside(self, id, currentTick, tickLower, tickUpper);
             uint256 lastGrowthInside = getLastGrowthInside(self, id, uniPositionKey);
             uint128 positionTotalLiquidity = uniV4.getPositionLiquidity(id, uniPositionKey);
@@ -155,6 +173,8 @@ library AngstromView {
         }
     }
 
+    /// @notice Returns the pending rewards held by Uniswap's PoolManager contract for the position
+    /// defined by the `(account, key, tickLower, tickUpper, salt)` tuple.
     function uniswapPendingRewards(
         address account,
         PoolKey memory key,
@@ -167,8 +187,13 @@ library AngstromView {
             PoolId id = key.toId();
             bytes32 uniPositionKey =
                 keccak256(abi.encodePacked(account, tickLower, tickUpper, salt));
-            (uint256 feeGrowthInside0X128, uint256 feeGrowthInside1X128) = uniV4.getFeeGrowthInside({poolId: id, tickLower: tickLower, tickUpper: tickUpper});
-            (uint128 liquidity, uint256 feeGrowthInside0LastX128, uint256 feeGrowthInside1LastX128) = uniV4.getPositionInfo({poolId: id, positionId: uniPositionKey});
+            (uint256 feeGrowthInside0X128, uint256 feeGrowthInside1X128) =
+                uniV4.getFeeGrowthInside({poolId: id, tickLower: tickLower, tickUpper: tickUpper});
+            (
+                uint128 liquidity,
+                uint256 feeGrowthInside0LastX128,
+                uint256 feeGrowthInside1LastX128
+            ) = uniV4.getPositionInfo({poolId: id, positionId: uniPositionKey});
             uint256 rewardsCurrency0 =
                 X128MathLib.fullMulX128(feeGrowthInside0X128 - feeGrowthInside0LastX128, liquidity);
             uint256 rewardsCurrency1 =

--- a/contracts/src/periphery/AngstromView.sol
+++ b/contracts/src/periphery/AngstromView.sol
@@ -4,18 +4,20 @@ pragma solidity ^0.8.0;
 import {PoolId, PoolIdLibrary} from "v4-core/src/types/PoolId.sol";
 import {PoolKey} from "v4-core/src/types/PoolKey.sol";
 
-import {IPoolManager, IUniV4} from "../interfaces/IUniV4.sol";
+import {IPoolManager} from "../interfaces/IUniV4.sol";
 import {IAngstromAuth} from "../interfaces/IAngstromAuth.sol";
 import {PoolConfigStore} from "../libraries/PoolConfigStore.sol";
 import {StoreKey} from "../libraries/PoolConfigStore.sol";
 import {X128MathLib} from "../libraries/X128MathLib.sol";
 import {Positions, Position} from "../types/Positions.sol";
+import {StateLibrary} from "v4-core/src/libraries/StateLibrary.sol";
 
-using IUniV4 for IPoolManager;
 using PoolIdLibrary for PoolId;
 
 /// @author philogy <https://github.com/philogy>
 library AngstromView {
+    using StateLibrary for IPoolManager;
+
     uint256 constant CONTROLLER_SLOT = 0;
 
     uint256 constant IS_NODE_SLOT = 1;
@@ -128,6 +130,7 @@ library AngstromView {
 
     /// @notice Returns the pending rewards held by the Angstrom hook for the position defined
     /// by the `(account, key, tickLower, tickUpper, salt)` tuple.
+    /// @dev Rewards from Angstrom are always in the Currency0 of the pair.
     function pendingRewards(
         IAngstromAuth self,
         address account,
@@ -141,7 +144,7 @@ library AngstromView {
             PoolId id = key.toId();
             bytes32 uniPositionKey =
                 keccak256(abi.encodePacked(account, tickLower, tickUpper, salt));
-            int24 currentTick = uniV4.getSlot0(id).tick();
+            (, int24 currentTick, , ) = uniV4.getSlot0(id);
             uint256 growthInside = getGrowthInside(self, id, currentTick, tickLower, tickUpper);
             uint256 lastGrowthInside = getLastGrowthInside(self, id, uniPositionKey);
             uint128 positionTotalLiquidity = uniV4.getPositionLiquidity(id, uniPositionKey);
@@ -149,6 +152,29 @@ library AngstromView {
                 X128MathLib.fullMulX128(growthInside - lastGrowthInside, positionTotalLiquidity);
 
             return rewards;
+        }
+    }
+
+    function uniswapPendingRewards(
+        address account,
+        PoolKey memory key,
+        int24 tickLower,
+        int24 tickUpper,
+        bytes32 salt,
+        IPoolManager uniV4
+    ) internal view returns (uint256, uint256) {
+        unchecked {
+            PoolId id = key.toId();
+            bytes32 uniPositionKey =
+                keccak256(abi.encodePacked(account, tickLower, tickUpper, salt));
+            (uint256 feeGrowthInside0X128, uint256 feeGrowthInside1X128) = uniV4.getFeeGrowthInside({poolId: id, tickLower: tickLower, tickUpper: tickUpper});
+            (uint128 liquidity, uint256 feeGrowthInside0LastX128, uint256 feeGrowthInside1LastX128) = uniV4.getPositionInfo({poolId: id, positionId: uniPositionKey});
+            uint256 rewardsCurrency0 =
+                X128MathLib.fullMulX128(feeGrowthInside0X128 - feeGrowthInside0LastX128, liquidity);
+            uint256 rewardsCurrency1 =
+                X128MathLib.fullMulX128(feeGrowthInside1X128 - feeGrowthInside1LastX128, liquidity);
+
+            return (rewardsCurrency0, rewardsCurrency1);
         }
     }
 }

--- a/contracts/test/Angstrom.t.sol
+++ b/contracts/test/Angstrom.t.sol
@@ -193,8 +193,6 @@ contract AngstromTest is BaseTest {
         swapAmount1 = bound(swapAmount1, 1e8, 10e18);
         swapAmount2 = bound(swapAmount2, 1e8, 10e18);
 
-        uint248 liq = 100_000e21;
-
         PoolKey memory pk = _createPool({
             tickSpacing: 60,
             unlockedFee: unlockedFee,

--- a/contracts/test/Angstrom.t.sol
+++ b/contracts/test/Angstrom.t.sol
@@ -71,9 +71,6 @@ contract AngstromTest is BaseTest {
         vm.prank(controller);
         angstrom.configurePool(asset0, asset1, 1, uint24(fee), 0, 0);
 
-        console.log("asset0: %s", asset0);
-        console.log("asset1: %s", asset1);
-
         Account memory user1 = makeAccount("user_1");
         MockERC20(asset0).mint(user1.addr, 100.0e18);
         vm.prank(user1.addr);

--- a/contracts/test/Angstrom.t.sol
+++ b/contracts/test/Angstrom.t.sol
@@ -195,7 +195,12 @@ contract AngstromTest is BaseTest {
 
         uint248 liq = 100_000e21;
 
-        PoolKey memory pk = _createPool(60, unlockedFee, liq, 0);
+        PoolKey memory pk = _createPool({
+            tickSpacing: 60,
+            unlockedFee: unlockedFee,
+            startLiquidity: 100_000e21,
+            protocolUnlockedFee: 0
+        });
 
         vm.prank(node.addr);
         angstrom.execute("");

--- a/contracts/test/Angstrom.t.sol
+++ b/contracts/test/Angstrom.t.sol
@@ -45,7 +45,7 @@ contract AngstromTest is BaseTest {
 
     RouterActor actor;
 
-    function setUp() public {
+    function setUp() public virtual {
         uni = new PoolManager(address(0));
         angstrom = Angstrom(deployAngstrom(type(Angstrom).creationCode, uni, controller));
         domainSeparator = computeDomainSeparator(address(angstrom));
@@ -262,7 +262,7 @@ contract AngstromTest is BaseTest {
         uint24 unlockedFee,
         uint248 startLiquidity,
         uint24 protocolUnlockedFee
-    ) internal returns (PoolKey memory pk) {
+    ) internal virtual returns (PoolKey memory pk) {
         vm.prank(controller);
         angstrom.configurePool(asset0, asset1, tickSpacing, 0, unlockedFee, protocolUnlockedFee);
         angstrom.initializePool(asset0, asset1, 0, TickMath.getSqrtPriceAtTick(0));

--- a/contracts/test/AngstromAdapter.t.sol
+++ b/contracts/test/AngstromAdapter.t.sol
@@ -731,18 +731,18 @@ contract AngstromAdapterTest is BaseTest {
     }
 
     function _prepareUsers(
-        address asset0,
-        Account memory user1,
-        Account memory user2,
+        address _asset0,
+        Account memory _user1,
+        Account memory _user2,
         uint128 amount
     ) internal {
-        MockERC20(asset0).mint(user1.addr, amount);
-        MockERC20(asset0).mint(user2.addr, amount);
+        MockERC20(_asset0).mint(_user1.addr, amount);
+        MockERC20(_asset0).mint(_user2.addr, amount);
 
-        vm.prank(user1.addr);
-        MockERC20(asset0).approve(address(adapter), type(uint256).max);
+        vm.prank(_user1.addr);
+        MockERC20(_asset0).approve(address(adapter), type(uint256).max);
 
-        vm.prank(user2.addr);
-        MockERC20(asset0).approve(address(actor), type(uint256).max);
+        vm.prank(_user2.addr);
+        MockERC20(_asset0).approve(address(actor), type(uint256).max);
     }
 }

--- a/contracts/test/_helpers/BaseTest.sol
+++ b/contracts/test/_helpers/BaseTest.sol
@@ -374,8 +374,11 @@ contract BaseTest is Test, HookDeployer {
         uint256 LAST_BLOCK_BIT_OFFSET = 0;
         uint256 STORE_BIT_OFFSET = 64;
         address configStore = PoolConfigStore.unwrap(angstrom.configStore());
-        uint256 slotData = (uint256(blockNumber) << LAST_BLOCK_BIT_OFFSET) | (uint256(uint160(configStore)) << STORE_BIT_OFFSET);
-        vm.store(address(angstrom), bytes32(LAST_BLOCK_CONFIG_STORE_SLOT), bytes32(uint256(slotData)));
+        uint256 slotData = (uint256(blockNumber) << LAST_BLOCK_BIT_OFFSET)
+            | (uint256(uint160(configStore)) << STORE_BIT_OFFSET);
+        vm.store(
+            address(angstrom), bytes32(LAST_BLOCK_CONFIG_STORE_SLOT), bytes32(uint256(slotData))
+        );
         uint64 lastBlockUpdated = angstrom.lastBlockUpdated();
         assertEq(blockNumber, lastBlockUpdated, "lastBlockUpdated not updated as expected");
         address configStoreAfter = PoolConfigStore.unwrap(angstrom.configStore());

--- a/contracts/test/_helpers/BaseTest.sol
+++ b/contracts/test/_helpers/BaseTest.sol
@@ -368,4 +368,17 @@ contract BaseTest is Test, HookDeployer {
         if (asset0 > asset1) return (asset1, asset0);
         return (asset0, asset1);
     }
+
+    function setAngstromLastBlockUpdated(IAngstromAuth angstrom, uint64 blockNumber) public {
+        uint256 LAST_BLOCK_CONFIG_STORE_SLOT = 3;
+        uint256 LAST_BLOCK_BIT_OFFSET = 0;
+        uint256 STORE_BIT_OFFSET = 64;
+        address configStore = PoolConfigStore.unwrap(angstrom.configStore());
+        uint256 slotData = (uint256(blockNumber) << LAST_BLOCK_BIT_OFFSET) | (uint256(uint160(configStore)) << STORE_BIT_OFFSET);
+        vm.store(address(angstrom), bytes32(LAST_BLOCK_CONFIG_STORE_SLOT), bytes32(uint256(slotData)));
+        uint64 lastBlockUpdated = angstrom.lastBlockUpdated();
+        assertEq(blockNumber, lastBlockUpdated, "lastBlockUpdated not updated as expected");
+        address configStoreAfter = PoolConfigStore.unwrap(angstrom.configStore());
+        assertEq(configStore, configStoreAfter, "configStore should not have changed");
+    }
 }

--- a/contracts/test/_reference/Bundle.sol
+++ b/contracts/test/_reference/Bundle.sol
@@ -6,7 +6,7 @@ import {Asset, AssetLib} from "./Asset.sol";
 import {Pair, PairLib} from "./Pair.sol";
 import {PriceAB as Price10} from "src/types/Price.sol";
 import {TopOfBlockOrder, OrdersLib} from "./OrderTypes.sol";
-import {PoolUpdate, PoolUpdateLib} from "./PoolUpdate.sol";
+import {PoolUpdate, RewardsUpdate, PoolUpdateLib} from "./PoolUpdate.sol";
 import {BalanceDelta} from "v4-core/src/types/BalanceDelta.sol";
 
 struct Bundle {
@@ -99,6 +99,39 @@ library BundleLib {
         newPairs[self.pairs.length].asset1 = asset1;
         newPairs[self.pairs.length].price10 = price10;
         self.pairs = newPairs;
+        return self;
+    }
+
+    function addPoolUpdate(
+        Bundle memory self,
+        address assetIn,
+        address assetOut,
+        uint128 amountIn,
+        bool onlyCurrent,
+        uint128 onlyCurrentQuantity,
+        int24 startTick,
+        uint128 startLiquidity,
+        uint128[] memory quantities,
+        uint160 rewardChecksum
+    ) internal pure returns (Bundle memory) {
+        PoolUpdate[] memory newPoolUpdates = new PoolUpdate[](self.poolUpdates.length + 1);
+        for (uint256 i = 0; i < self.poolUpdates.length; i++) {
+            newPoolUpdates[i] = self.poolUpdates[i];
+        }
+        newPoolUpdates[self.poolUpdates.length] = PoolUpdate(
+            assetIn,
+            assetOut,
+            amountIn,
+            RewardsUpdate(
+                onlyCurrent,
+                onlyCurrentQuantity,
+                startTick,
+                startLiquidity,
+                quantities,
+                rewardChecksum
+            )
+        );
+        self.poolUpdates = newPoolUpdates;
         return self;
     }
 

--- a/contracts/test/fork/MainnetFork.t.sol
+++ b/contracts/test/fork/MainnetFork.t.sol
@@ -44,16 +44,6 @@ contract MainnetForkTest is AngstromTest {
     using IUniV4 for PoolManager;
     using PoolUpdateLib for PoolUpdate;
 
-    struct ModifyLiquidityParams {
-        // the lower and upper tick of the position
-        int24 tickLower;
-        int24 tickUpper;
-        // how to modify the liquidity
-        int256 liquidityDelta;
-        // a value to set if you want unique liquidity positions at the same range
-        bytes32 salt;
-    }
-
     address constant WETH = 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2;
     address constant USDC = 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48;
 
@@ -83,23 +73,19 @@ contract MainnetForkTest is AngstromTest {
     }
 
     // get the WETH/USDC pool global rewards growth and check that it is nonzero
-    function test_getGlobalRewardsGrowth() public {
+    function test_getGlobalRewardsGrowth() public view {
         PoolId id = PoolId.wrap(
             bytes32(0xe500210c7ea6bfd9f69dce044b09ef384ec2b34832f132baec3b418208e3a657)
         );
         uint256 poolRewardsGlobalGrowth = angstrom.poolRewardsGlobalGrowth({id: id});
-        emit log_named_uint("poolRewardsGlobalGrowth", poolRewardsGlobalGrowth);
+        assertGt(poolRewardsGlobalGrowth, 0, "poolRewardsGlobalGrowth should be nonzero");
     }
 
-    function test_claimRewards() public {
+    function test_claimRewards_existingRewards() public {
         // emulate claim in https://etherscan.io/tx/0x3770e2e8caa1a106fd3e67b60a221815b30122d330e7663a17a09e18f001cef7
         // fork at specific block
         uint256 forkId = vm.createSelectFork("mainnet", 24831188);
         assertEq(vm.activeFork(), forkId);
-
-        // vm.roll(block.number + 1);
-        // emit log_named_uint("block.number", block.number);
-        // setAngstromLastBlockUpdated(uint64(block.number));
 
         address user = 0x35b9571eF5eAA24EC626ACdDDE3B02B595A5eB0B;
         address uniPositionManager = 0xbD216513d74C8cf14cf4747E6AaA6420FF64ee9e;
@@ -125,18 +111,19 @@ contract MainnetForkTest is AngstromTest {
 
         bytes memory callData;
         {
-            bytes memory actions =
-                abi.encodePacked(bytes1(uint8(Actions.DECREASE_LIQUIDITY)), bytes1(uint8(Actions.TAKE_PAIR)));
+            bytes memory actions = abi.encodePacked(
+                bytes1(uint8(Actions.DECREASE_LIQUIDITY)), bytes1(uint8(Actions.TAKE_PAIR))
+            );
             bytes memory hookData;
             uint256 deadline = 1775606188;
             bytes[] memory parameters = new bytes[](2);
             // (uint256 tokenId, uint256 liquidity, uint128 amount0Min, uint128 amount1Min, bytes calldata hookData)
             parameters[0] = abi.encode(tokenId, 0, 0, 0, hookData);
             parameters[1] = abi.encode(pk.currency0, pk.currency1, user);
-            // (bytes calldata actions, bytes[] calldata parameters) = data.decodeActionsRouterParams()
 
             bytes memory unlockData = abi.encode(actions, parameters);
-            callData = abi.encodeWithSignature("modifyLiquidities(bytes,uint256)", unlockData, deadline);
+            callData =
+                abi.encodeWithSignature("modifyLiquidities(bytes,uint256)", unlockData, deadline);
         }
 
         (uint256 rewardsCurrency0, uint256 rewardsCurrency1) = AngstromView.uniswapPendingRewards({
@@ -150,7 +137,7 @@ contract MainnetForkTest is AngstromTest {
 
         vm.prank(user);
         {
-            (bool success, ) = address(uniPositionManager).call(callData);
+            (bool success,) = address(uniPositionManager).call(callData);
             require(success, "mocked call failed");
         }
 
@@ -169,7 +156,7 @@ contract MainnetForkTest is AngstromTest {
         );
     }
 
-    function test_rewardsClaiming() public {
+    function test_claimRewards_generatedRewards() public {
         uint248 liq = 100_000e21;
         uint248 startLiquidity = liq;
         uint256 bundleFee = 0.002e6;
@@ -256,7 +243,7 @@ contract MainnetForkTest is AngstromTest {
             onlyCurrent: true,
             onlyCurrentQuantity: 1e18,
             startTick: 0,
-            startLiquidity: 0,
+            startLiquidity: uint128(100_000e21),
             quantities: quantities,
             rewardChecksum: 0
         });
@@ -268,29 +255,13 @@ contract MainnetForkTest is AngstromTest {
         bundle.assets[1].settle += 10.0e18;
 
         bundle.assets[0].save -= bundle.poolUpdates[0].rewardUpdate.onlyCurrentQuantity;
-        // bundle.assets[0].take += bundle.poolUpdates[0].amountIn;
         uint256 existingLiquidity = uni.getPoolLiquidity(pk.toId());
-        emit log_named_uint("existingLiquidity", existingLiquidity);
-        // returns 100000000000000000000000000 (as expected)
-
-        emit log(bundle.poolUpdates[0].rewardUpdate.toStr());
-        // returns RewardsUpdate::CurrentOnly { amount: 1000000000000000000 } (as expected)
-
-        // manually write rewards slot
-        uint256 rewardsMapSlot =
-        // uint256(bytes32(keccak256(abi.encode(pk.toId(), POOL_REWARDS_SLOT)))) + REWARD_GROWTH_SIZE;
-         uint256(bytes32(keccak256(abi.encode(pk.toId(), 7)))) + 16777216;
-        vm.store(address(angstrom), bytes32(rewardsMapSlot), bytes32(uint256(1e30)));
 
         bytes memory payload = bundle.encode(rawGetConfigStore(address(angstrom)));
         vm.prank(node.addr);
         angstrom.execute(payload);
-        // test_userOrderWithFees();
 
-        // int24 tickLower = -1 * int24(uint24(60));
-        // int24 tickUpper = 1 * int24(uint24(60));
         uint256 poolRewardsGlobalGrowth = angstrom.poolRewardsGlobalGrowth({id: pk.toId()});
-        emit log_named_uint("poolRewardsGlobalGrowth", poolRewardsGlobalGrowth);
         assertGt(poolRewardsGlobalGrowth, 0, "poolRewardsGlobalGrowth should be nonzero");
         {
             uint256 lastGrowthInside = angstrom.getLastGrowthInside({
@@ -301,10 +272,9 @@ contract MainnetForkTest is AngstromTest {
                     )
                 )
             });
-            emit log_named_uint("lastGrowthInside", lastGrowthInside);
+            assertEq(lastGrowthInside, 0, "lastGrowthInside should be zero before call");
         }
 
-        // PoolKey memory pk = poolKey(angstrom, asset0, asset1, 60);
         uint256 pendingRewards = angstrom.pendingRewards({
             account: address(actor),
             key: pk,
@@ -315,7 +285,6 @@ contract MainnetForkTest is AngstromTest {
         });
         assertGt(pendingRewards, 0, "pendingRewards should be nonzero");
         uint256 asset0BalanceBefore = MockERC20(asset0).balanceOf(address(actor));
-        emit log_named_uint("pendingRewards", pendingRewards);
 
         actor.modifyLiquidity(
             pk, -1 * int24(uint24(60)), 1 * int24(uint24(60)), int256(uint256(0)), bytes32(0)
@@ -324,7 +293,7 @@ contract MainnetForkTest is AngstromTest {
         {
             uint256 asset0BalanceAfter = MockERC20(asset0).balanceOf(address(actor));
             assertEq(
-                asset0BalanceAfter, asset0BalanceBefore + pendingRewards, "pendingRewards incorrect"
+                asset0BalanceAfter - asset0BalanceBefore, pendingRewards, "pendingRewards incorrect"
             );
         }
 
@@ -337,6 +306,24 @@ contract MainnetForkTest is AngstromTest {
             uniV4: uni
         });
         assertEq(pendingRewards, 0, "pendingRewards should be zero");
+        assertEq(
+            uni.getPoolLiquidity(pk.toId()), existingLiquidity, "call should not modify liquidity"
+        );
+        {
+            uint256 lastGrowthInside = angstrom.getLastGrowthInside({
+                id: pk.toId(),
+                uniPositionKey: keccak256(
+                    abi.encodePacked(
+                        address(actor), -1 * int24(uint24(60)), 1 * int24(uint24(60)), bytes32(0)
+                    )
+                )
+            });
+            assertEq(
+                lastGrowthInside,
+                poolRewardsGlobalGrowth,
+                "lastGrowthInside should equal poolRewardsGlobalGrowth after call"
+            );
+        }
     }
 
     // override function to allow different store index which is appropriate for mainnet

--- a/contracts/test/fork/MainnetFork.t.sol
+++ b/contracts/test/fork/MainnetFork.t.sol
@@ -185,9 +185,6 @@ contract MainnetForkTest is AngstromTest {
             );
         }
 
-        console.log("asset0: %s", asset0);
-        console.log("asset1: %s", asset1);
-
         Account memory user1 = makeAccount("user_1");
         MockERC20(asset0).mint(user1.addr, 100.0e18);
         vm.prank(user1.addr);

--- a/contracts/test/fork/MainnetFork.t.sol
+++ b/contracts/test/fork/MainnetFork.t.sol
@@ -24,11 +24,13 @@ import {Hooks} from "v4-core/src/libraries/Hooks.sol";
 
 // to force compile
 import {IPositionDescriptor} from "v4-periphery/src/interfaces/IPositionDescriptor.sol";
+import {Actions} from "v4-periphery/src/libraries/Actions.sol";
 import {console} from "forge-std/console.sol";
 
 import {IUniV4} from "src/interfaces/IUniV4.sol";
 import {PoolUpdateLib, PoolUpdate, RewardsUpdate} from "test/_reference/PoolUpdate.sol";
 import {PoolConfigStore} from "src/libraries/PoolConfigStore.sol";
+import {Actions} from "v4-periphery/src/libraries/Actions.sol";
 
 contract MainnetForkTest is AngstromTest {
     using AngstromView for Angstrom;
@@ -57,7 +59,7 @@ contract MainnetForkTest is AngstromTest {
 
     function setUp() public override {
         // fork at specific block
-        uint256 forkId = vm.createSelectFork("mainnet", 24831188);
+        uint256 forkId = vm.createSelectFork("mainnet");
         assertEq(vm.activeFork(), forkId);
 
         uni = PoolManager(address(0x000000000004444c5dc75cB358380D2e3dE08A90));
@@ -91,9 +93,9 @@ contract MainnetForkTest is AngstromTest {
 
     function test_claimRewards() public {
         // emulate claim in https://etherscan.io/tx/0x3770e2e8caa1a106fd3e67b60a221815b30122d330e7663a17a09e18f001cef7
-        // // fork at specific block
-        // uint256 forkId = vm.createSelectFork("mainnet", 24831188);
-        // assertEq(vm.activeFork(), forkId);
+        // fork at specific block
+        uint256 forkId = vm.createSelectFork("mainnet", 24831188);
+        assertEq(vm.activeFork(), forkId);
 
         // vm.roll(block.number + 1);
         // emit log_named_uint("block.number", block.number);
@@ -114,56 +116,56 @@ contract MainnetForkTest is AngstromTest {
             uniV4: uni
         });
 
-        emit log_named_uint("pendingRewards", pendingRewards);
         // pending rewards should be 226319524 at this block
         assertGt(pendingRewards, 0, "pendingRewards should be nonzero");
 
         uint256 existingLiquidity = uni.getPoolLiquidity(pk.toId());
         uint256 asset0BalanceBefore = MockERC20(USDC).balanceOf(address(user));
+        uint256 asset1BalanceBefore = MockERC20(WETH).balanceOf(address(user));
 
-        uint256 deadline = 1775606188;
         bytes memory callData;
         {
-            bytes memory actions = abi.encodePacked(bytes1(uint8(0x01)));
-
-            // (uint256 tokenId, uint256 liquidity, uint128 amount0Min, uint128 amount1Min, bytes calldata hookData) =
-            //             parameters.decodeModifyLiquidityParams();
-            uint256 liquidity = 0;
-            uint128 amount0Min = 0;
-            uint128 amount1Min = 0;
+            bytes memory actions =
+                abi.encodePacked(bytes1(uint8(Actions.DECREASE_LIQUIDITY)), bytes1(uint8(Actions.TAKE_PAIR)));
             bytes memory hookData;
-            bytes[] memory parameters = new bytes[](1);
-            parameters[0] = abi.encode(tokenId, liquidity, amount0Min, amount1Min, hookData);
+            uint256 deadline = 1775606188;
+            bytes[] memory parameters = new bytes[](2);
+            // (uint256 tokenId, uint256 liquidity, uint128 amount0Min, uint128 amount1Min, bytes calldata hookData)
+            parameters[0] = abi.encode(tokenId, 0, 0, 0, hookData);
+            parameters[1] = abi.encode(pk.currency0, pk.currency1, user);
             // (bytes calldata actions, bytes[] calldata parameters) = data.decodeActionsRouterParams()
 
             bytes memory unlockData = abi.encode(actions, parameters);
             callData = abi.encodeWithSignature("modifyLiquidities(bytes,uint256)", unlockData, deadline);
         }
 
-        vm.prank(user);
-        (bool success, ) = address(uniPositionManager).call(callData);
-        require(success, "mocked call failed");
+        (uint256 rewardsCurrency0, uint256 rewardsCurrency1) = AngstromView.uniswapPendingRewards({
+            account: uniPositionManager,
+            key: pk,
+            tickLower: 199320,
+            tickUpper: 201320,
+            salt: bytes32(tokenId),
+            uniV4: uni
+        });
 
-/**
         vm.prank(user);
-        // bytes memory callData =
-        callData =
-        //     abi.encodeWithSignature("modifyLiquidities(bytes,uint256)", unlockData, deadline);
-            // unmodified
-            // "0xdd46508f00000000000000000000000000000000000000000000000000000000000000400000000000000000000000000000000000000000000000000000000069d599ac0000000000000000000000000000000000000000000000000000000000000260000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000800000000000000000000000000000000000000000000000000000000000000002011100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000000000014000000000000000000000000000000000000000000000000000000000000000e0000000000000000000000000000000000000000000000000000000000002f0bf000000000000000000000000000000000000000000000000000ee04f601baa56000000000000000000000000000000000000000000000000000000045c14858e000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000a000000000000000000000000000000000000000000000000000000000000000140000000aa232009084bd71a5797d089aa4edfad40000000000000000000000000000000000000000000000000000000000000000000000000000000000000060000000000000000000000000a0b86991c6218b36c1d19d4a2e9eb0ce3606eb48000000000000000000000000c02aaa39b223fe8d0a0e5c4f27ead9083c756cc20000000000000000000000000000000000000000000000000000000000000001";
-        //     // modified
-            "0xdd46508f00000000000000000000000000000000000000000000000000000000000000400000000000000000000000000000000000000000000000000000000069d599ac0000000000000000000000000000000000000000000000000000000000000260000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000800000000000000000000000000000000000000000000000000000000000000002011100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000000000014000000000000000000000000000000000000000000000000000000000000000e0000000000000000000000000000000000000000000000000000000000002f0bf0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000045c14858e000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000a000000000000000000000000000000000000000000000000000000000000000140000000aa232009084bd71a5797d089aa4edfad40000000000000000000000000000000000000000000000000000000000000000000000000000000000000060000000000000000000000000a0b86991c6218b36c1d19d4a2e9eb0ce3606eb48000000000000000000000000c02aaa39b223fe8d0a0e5c4f27ead9083c756cc20000000000000000000000000000000000000000000000000000000000000001";
-        (success, ) = uniPositionManager.call(callData);
-        require(success, "mocked call 2 failed");
-**/
+        {
+            (bool success, ) = address(uniPositionManager).call(callData);
+            require(success, "mocked call failed");
+        }
+
         assertEq(
             uni.getPoolLiquidity(pk.toId()), existingLiquidity, "call should not modify liquidity"
         );
-        uint256 asset0BalanceAfter = MockERC20(USDC).balanceOf(address(user));
         assertEq(
-            asset0BalanceAfter - asset0BalanceBefore,
-            pendingRewards,
-            "pendingRewards amount not equal to transfer amount"
+            MockERC20(USDC).balanceOf(address(user)) - asset0BalanceBefore,
+            pendingRewards + rewardsCurrency0,
+            "pendingRewards + rewardsCurrency0 amount not equal to transfer amount"
+        );
+        assertEq(
+            MockERC20(WETH).balanceOf(address(user)) - asset1BalanceBefore,
+            rewardsCurrency1,
+            "rewardsCurrency1 amount not equal to transfer amount"
         );
     }
 
@@ -368,18 +370,5 @@ contract MainnetForkTest is AngstromTest {
         }
 
         return pk;
-    }
-
-    function setAngstromLastBlockUpdated(uint64 blockNumber) public {
-        uint256 LAST_BLOCK_CONFIG_STORE_SLOT = 3;
-        uint256 LAST_BLOCK_BIT_OFFSET = 0;
-        uint256 STORE_BIT_OFFSET = 64;
-        address configStore = PoolConfigStore.unwrap(angstrom.configStore());
-        uint256 slotData = (uint256(blockNumber) << LAST_BLOCK_BIT_OFFSET) | (uint256(uint160(configStore)) << STORE_BIT_OFFSET);
-        vm.store(address(angstrom), bytes32(LAST_BLOCK_CONFIG_STORE_SLOT), bytes32(uint256(slotData)));
-        uint64 lastBlockUpdated = angstrom.lastBlockUpdated();
-        assertEq(blockNumber, lastBlockUpdated, "lastBlockUpdated not updated as expected");
-        address configStoreAfter = PoolConfigStore.unwrap(angstrom.configStore());
-        assertEq(configStore, configStoreAfter, "configStore should not have changed");
     }
 }

--- a/contracts/test/fork/MainnetFork.t.sol
+++ b/contracts/test/fork/MainnetFork.t.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
+import {AngstromTest} from "test/Angstrom.t.sol";
 import {BaseTest} from "test/_helpers/BaseTest.sol";
 import {PoolManager} from "v4-core/src/PoolManager.sol";
 import {TickMath} from "v4-core/src/libraries/TickMath.sol";
@@ -28,7 +29,7 @@ import {console} from "forge-std/console.sol";
 import {IUniV4} from "src/interfaces/IUniV4.sol";
 import {PoolUpdateLib, PoolUpdate, RewardsUpdate} from "test/_reference/PoolUpdate.sol";
 
-contract MainnetForkTest is BaseTest {
+contract MainnetForkTest is AngstromTest {
     using AngstromView for Angstrom;
     using SafeTransferLib for address;
 
@@ -40,18 +41,7 @@ contract MainnetForkTest is BaseTest {
     using IUniV4 for PoolManager;
     using PoolUpdateLib for PoolUpdate;
 
-    PoolManager uni;
-    Angstrom angstrom;
-    bytes32 domainSeparator;
-
-    address controller;
-    Account node = makeAccount("node");
-    address asset0;
-    address asset1;
-
-    RouterActor actor;
-
-    function setUp() public {
+    function setUp() public override {
         // Create and select in one call
         uint256 forkId = vm.createSelectFork("mainnet");
         assertEq(vm.activeFork(), forkId);
@@ -255,223 +245,13 @@ contract MainnetForkTest is BaseTest {
         assertEq(pendingRewards, 0, "pendingRewards should be zero");
     }
 
-    function test_userOrderWithFees() public {
-        uint256 fee = 0.002e6;
-
-        vm.prank(controller);
-        angstrom.configurePool(asset0, asset1, 1, uint24(fee), 0, 0);
-
-        console.log("asset0: %s", asset0);
-        console.log("asset1: %s", asset1);
-
-        Account memory user1 = makeAccount("user_1");
-        MockERC20(asset0).mint(user1.addr, 100.0e18);
-        vm.prank(user1.addr);
-        MockERC20(asset0).approve(address(angstrom), type(uint256).max);
-
-        Account memory user2 = makeAccount("user_2");
-        MockERC20(asset1).mint(user2.addr, 100.0e18);
-        vm.prank(user2.addr);
-        MockERC20(asset1).approve(address(angstrom), type(uint256).max);
-
-        Price10 price = Price10.wrap(1e27);
-
-        Bundle memory bundle;
-
-        bundle.addAsset(asset0).addAsset(asset1).addPair(asset0, asset1, price);
-        bundle.userOrders = new UserOrder[](2);
-
-        {
-            PartialStandingOrder memory order;
-            order.maxAmountIn = 20.0e18;
-            order.maxExtraFeeAsset0 = 1.3e18;
-            order.minPrice = 0.1e27;
-            order.assetIn = asset0;
-            order.assetOut = asset1;
-            order.deadline = u40(block.timestamp + 60 minutes);
-            sign(user1, order.meta, digest712(order.hash()));
-            order.extraFeeAsset0 = 1.0e18;
-            order.amountFilled = 10.0e18;
-            bundle.userOrders[0] = UserOrderLib.from(order);
-        }
-
-        {
-            ExactFlashOrder memory order;
-            order.exactIn = true;
-            order.amount = 9.200400801603206413e18;
-            order.maxExtraFeeAsset0 = 0.2e18;
-            order.minPrice = 0.1e27;
-            order.assetIn = asset1;
-            order.assetOut = asset0;
-            order.validForBlock = u64(block.number);
-            sign(user2, order.meta, digest712(order.hash()));
-            order.extraFeeAsset0 = 0.2e18;
-            bundle.userOrders[1] = UserOrderLib.from(order);
-        }
-
-        bundle.assets[0].save += 1.018e18;
-        bundle.assets[1].save += 0.218400801603206413e18;
-        bundle.assets[1].take += 10.0e18;
-        bundle.assets[1].settle += 10.0e18;
-
-        bytes memory payload = bundle.encode(rawGetConfigStore(address(angstrom)));
-        vm.prank(node.addr);
-        angstrom.execute(payload);
-    }
-
-    function test_fuzzing_swapWithUnlockData(
-        uint256 bnInput,
-        uint24 unlockedFee,
-        uint256 swapAmount1,
-        uint256 swapAmount2
-    ) public {
-        uint64 bn = bound_block(bnInput);
-        vm.roll(bn);
-
-        bytes32 digest = erc712Hash(
-            computeDomainSeparator(address(angstrom)),
-            keccak256(abi.encode(keccak256("AttestAngstromBlockEmpty(uint64 block_number)"), bn))
-        );
-        (uint8 v, bytes32 r, bytes32 s) = vm.sign(node.key, digest);
-
-        bytes memory unlockData = bytes.concat(bytes20(node.addr), r, s, bytes1(v));
-
-        unlockedFee = uint24(bound(unlockedFee, 0, MAX_UNLOCK_FEE_E6));
-        swapAmount1 = bound(swapAmount1, 1e8, 10e18);
-        swapAmount2 = bound(swapAmount2, 1e8, 10e18);
-
-        PoolKey memory pk = _createPool({
-            tickSpacing: 60,
-            unlockedFee: unlockedFee,
-            startLiquidity: 100_000e21,
-            protocolUnlockedFee: 0
-        });
-
-        uint256 pendingRewards = angstrom.pendingRewards({
-            account: address(actor),
-            key: pk,
-            tickLower: -1 * int24(uint24(60)),
-            tickUpper: 1 * int24(uint24(60)),
-            salt: bytes32(0),
-            uniV4: uni
-        });
-        assertEq(pendingRewards, 0, "pendingRewards should be zero before swaps");
-
-        vm.prank(node.addr);
-        angstrom.execute("");
-        int128 withFeeOut =
-            actor.swap(pk, true, -int256(swapAmount1), 4295128740, unlockData).amount1();
-
-        assertGe(withFeeOut, 0);
-        assertEq(angstrom.lastBlockUpdated(), bn);
-
-        withFeeOut = actor.swap(pk, true, -int256(swapAmount2), 4295128740, unlockData).amount1();
-        assertGe(withFeeOut, 0);
-
-        pendingRewards = angstrom.pendingRewards({
-            account: address(actor),
-            key: pk,
-            tickLower: -1 * int24(uint24(60)),
-            tickUpper: 1 * int24(uint24(60)),
-            salt: bytes32(0),
-            uniV4: uni
-        });
-        assertGt(pendingRewards, 0, "pendingRewards should be nonzero after swaps");
-    }
-
-    function test_claimRewards() public {
-        test_fuzzing_unlockSwapWithProtocolFee({
-            bnInput: 2 ** 32,
-            unlockedFee: 0.1e6,
-            swapAmount1: 1e18,
-            swapAmount2: 3e18,
-            protocol_unlock_swap_fee_e6: 0.01e6
-        });
-
-        PoolKey memory pk = poolKey(angstrom, asset0, asset1, 60);
-        uint256 pendingRewards = angstrom.pendingRewards({
-            account: address(actor),
-            key: pk,
-            tickLower: -1 * int24(uint24(60)),
-            tickUpper: 1 * int24(uint24(60)),
-            salt: bytes32(0),
-            uniV4: uni
-        });
-        assertGt(pendingRewards, 0, "pendingRewards should be nonzero");
-        uint256 asset0BalanceBefore = MockERC20(asset0).balanceOf(address(this));
-        emit log_named_uint("pendingRewards", pendingRewards);
-
-        actor.modifyLiquidity(
-            pk, -1 * int24(uint24(60)), 1 * int24(uint24(60)), int256(uint256(0)), bytes32(0)
-        );
-
-        uint256 asset0BalanceAfter = MockERC20(asset0).balanceOf(address(this));
-        assertEq(
-            asset0BalanceAfter, asset0BalanceBefore + pendingRewards, "pendingRewards incorrect"
-        );
-
-        pendingRewards = angstrom.pendingRewards({
-            account: address(actor),
-            key: pk,
-            tickLower: -1 * int24(uint24(60)),
-            tickUpper: 1 * int24(uint24(60)),
-            salt: bytes32(0),
-            uniV4: uni
-        });
-        assertEq(pendingRewards, 0, "pendingRewards should be zero");
-    }
-
-    function test_fuzzing_unlockSwapWithProtocolFee(
-        uint256 bnInput,
-        uint24 unlockedFee,
-        uint256 swapAmount1,
-        uint256 swapAmount2,
-        uint24 protocol_unlock_swap_fee_e6
-    ) public {
-        uint64 bn = bound_block(bnInput);
-        vm.roll(bn);
-
-        unlockedFee = uint24(bound(unlockedFee, 0, MAX_UNLOCK_FEE_E6));
-        protocol_unlock_swap_fee_e6 = uint24(bound(protocol_unlock_swap_fee_e6, 0, 0.02e6));
-        swapAmount1 = bound(swapAmount1, 1e8, 10e18);
-        swapAmount2 = bound(swapAmount2, 1e8, 10e18);
-
-        uint248 liq = 100_000e21;
-
-        PoolKey memory pk = _createPool(60, unlockedFee, liq, protocol_unlock_swap_fee_e6);
-
-        vm.prank(node.addr);
-        angstrom.execute("");
-        int128 withFeeOut1 = actor.swap(pk, true, -int256(swapAmount1), 4295128740, "").amount1();
-
-        assertGe(withFeeOut1, 0);
-        assertEq(angstrom.lastBlockUpdated(), bn);
-
-        int128 withFeeOut2 = actor.swap(pk, true, -int256(swapAmount2), 4295128740, "").amount1();
-        assertGe(withFeeOut2, 0);
-
-        address fee_recv = makeAddr("temp_fee_recv");
-        vm.prank(controller);
-        angstrom.collect_unlock_swap_fees(fee_recv, abi.encodePacked(asset1));
-
-        uint256 fee_collected = asset1.balanceOf(fee_recv);
-
-        console.log("here");
-
-        uint256 effective_fee_share =
-            (fee_collected * 1e18) / (uint128(withFeeOut1) + uint128(withFeeOut2) + fee_collected);
-
-        console.log("here? (%s)", protocol_unlock_swap_fee_e6);
-
-        assertApproxEqRel(effective_fee_share, uint256(protocol_unlock_swap_fee_e6) * 1e12, 0.01e18);
-    }
-
+    // override function to allow different store index which is appropriate for mainnet
     function _createPool(
         uint16 tickSpacing,
         uint24 unlockedFee,
         uint248 startLiquidity,
         uint24 protocolUnlockedFee
-    ) internal returns (PoolKey memory pk) {
+    ) internal override returns (PoolKey memory pk) {
         vm.prank(controller);
         angstrom.configurePool({
             asset0: asset0,
@@ -496,17 +276,5 @@ contract MainnetForkTest is BaseTest {
         }
 
         return pk;
-    }
-
-    function bound_block(uint256 bn) internal pure returns (uint64) {
-        return bound_block(bn, type(uint64).max);
-    }
-
-    function bound_block(uint256 bn, uint64 upper) internal pure returns (uint64) {
-        return uint64(bound(bn, 1, upper));
-    }
-
-    function digest712(bytes32 structHash) internal view returns (bytes32) {
-        return erc712Hash(domainSeparator, structHash);
     }
 }

--- a/contracts/test/fork/MainnetFork.t.sol
+++ b/contracts/test/fork/MainnetFork.t.sol
@@ -28,6 +28,7 @@ import {console} from "forge-std/console.sol";
 
 import {IUniV4} from "src/interfaces/IUniV4.sol";
 import {PoolUpdateLib, PoolUpdate, RewardsUpdate} from "test/_reference/PoolUpdate.sol";
+import {PoolConfigStore} from "src/libraries/PoolConfigStore.sol";
 
 contract MainnetForkTest is AngstromTest {
     using AngstromView for Angstrom;
@@ -41,9 +42,22 @@ contract MainnetForkTest is AngstromTest {
     using IUniV4 for PoolManager;
     using PoolUpdateLib for PoolUpdate;
 
+    struct ModifyLiquidityParams {
+        // the lower and upper tick of the position
+        int24 tickLower;
+        int24 tickUpper;
+        // how to modify the liquidity
+        int256 liquidityDelta;
+        // a value to set if you want unique liquidity positions at the same range
+        bytes32 salt;
+    }
+
+    address constant WETH = 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2;
+    address constant USDC = 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48;
+
     function setUp() public override {
-        // Create and select in one call
-        uint256 forkId = vm.createSelectFork("mainnet");
+        // fork at specific block
+        uint256 forkId = vm.createSelectFork("mainnet", 24831188);
         assertEq(vm.activeFork(), forkId);
 
         uni = PoolManager(address(0x000000000004444c5dc75cB358380D2e3dE08A90));
@@ -73,6 +87,84 @@ contract MainnetForkTest is AngstromTest {
         );
         uint256 poolRewardsGlobalGrowth = angstrom.poolRewardsGlobalGrowth({id: id});
         emit log_named_uint("poolRewardsGlobalGrowth", poolRewardsGlobalGrowth);
+    }
+
+    function test_claimRewards() public {
+        // emulate claim in https://etherscan.io/tx/0x3770e2e8caa1a106fd3e67b60a221815b30122d330e7663a17a09e18f001cef7
+        // // fork at specific block
+        // uint256 forkId = vm.createSelectFork("mainnet", 24831188);
+        // assertEq(vm.activeFork(), forkId);
+
+        // vm.roll(block.number + 1);
+        // emit log_named_uint("block.number", block.number);
+        // setAngstromLastBlockUpdated(uint64(block.number));
+
+        address user = 0x35b9571eF5eAA24EC626ACdDDE3B02B595A5eB0B;
+        address uniPositionManager = 0xbD216513d74C8cf14cf4747E6AaA6420FF64ee9e;
+
+        int24 spacing = 10;
+        uint256 tokenId = 192703;
+        PoolKey memory pk = poolKey(angstrom, USDC, WETH, spacing);
+        uint256 pendingRewards = angstrom.pendingRewards({
+            account: uniPositionManager,
+            key: pk,
+            tickLower: 199320,
+            tickUpper: 201320,
+            salt: bytes32(tokenId),
+            uniV4: uni
+        });
+
+        emit log_named_uint("pendingRewards", pendingRewards);
+        // pending rewards should be 226319524 at this block
+        assertGt(pendingRewards, 0, "pendingRewards should be nonzero");
+
+        uint256 existingLiquidity = uni.getPoolLiquidity(pk.toId());
+        uint256 asset0BalanceBefore = MockERC20(USDC).balanceOf(address(user));
+
+        uint256 deadline = 1775606188;
+        bytes memory callData;
+        {
+            bytes memory actions = abi.encodePacked(bytes1(uint8(0x01)));
+
+            // (uint256 tokenId, uint256 liquidity, uint128 amount0Min, uint128 amount1Min, bytes calldata hookData) =
+            //             parameters.decodeModifyLiquidityParams();
+            uint256 liquidity = 0;
+            uint128 amount0Min = 0;
+            uint128 amount1Min = 0;
+            bytes memory hookData;
+            bytes[] memory parameters = new bytes[](1);
+            parameters[0] = abi.encode(tokenId, liquidity, amount0Min, amount1Min, hookData);
+            // (bytes calldata actions, bytes[] calldata parameters) = data.decodeActionsRouterParams()
+
+            bytes memory unlockData = abi.encode(actions, parameters);
+            callData = abi.encodeWithSignature("modifyLiquidities(bytes,uint256)", unlockData, deadline);
+        }
+
+        vm.prank(user);
+        (bool success, ) = address(uniPositionManager).call(callData);
+        require(success, "mocked call failed");
+
+/**
+        vm.prank(user);
+        // bytes memory callData =
+        callData =
+        //     abi.encodeWithSignature("modifyLiquidities(bytes,uint256)", unlockData, deadline);
+            // unmodified
+            // "0xdd46508f00000000000000000000000000000000000000000000000000000000000000400000000000000000000000000000000000000000000000000000000069d599ac0000000000000000000000000000000000000000000000000000000000000260000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000800000000000000000000000000000000000000000000000000000000000000002011100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000000000014000000000000000000000000000000000000000000000000000000000000000e0000000000000000000000000000000000000000000000000000000000002f0bf000000000000000000000000000000000000000000000000000ee04f601baa56000000000000000000000000000000000000000000000000000000045c14858e000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000a000000000000000000000000000000000000000000000000000000000000000140000000aa232009084bd71a5797d089aa4edfad40000000000000000000000000000000000000000000000000000000000000000000000000000000000000060000000000000000000000000a0b86991c6218b36c1d19d4a2e9eb0ce3606eb48000000000000000000000000c02aaa39b223fe8d0a0e5c4f27ead9083c756cc20000000000000000000000000000000000000000000000000000000000000001";
+        //     // modified
+            "0xdd46508f00000000000000000000000000000000000000000000000000000000000000400000000000000000000000000000000000000000000000000000000069d599ac0000000000000000000000000000000000000000000000000000000000000260000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000800000000000000000000000000000000000000000000000000000000000000002011100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000000000014000000000000000000000000000000000000000000000000000000000000000e0000000000000000000000000000000000000000000000000000000000002f0bf0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000045c14858e000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000a000000000000000000000000000000000000000000000000000000000000000140000000aa232009084bd71a5797d089aa4edfad40000000000000000000000000000000000000000000000000000000000000000000000000000000000000060000000000000000000000000a0b86991c6218b36c1d19d4a2e9eb0ce3606eb48000000000000000000000000c02aaa39b223fe8d0a0e5c4f27ead9083c756cc20000000000000000000000000000000000000000000000000000000000000001";
+        (success, ) = uniPositionManager.call(callData);
+        require(success, "mocked call 2 failed");
+**/
+        assertEq(
+            uni.getPoolLiquidity(pk.toId()), existingLiquidity, "call should not modify liquidity"
+        );
+        uint256 asset0BalanceAfter = MockERC20(USDC).balanceOf(address(user));
+        assertEq(
+            asset0BalanceAfter - asset0BalanceBefore,
+            pendingRewards,
+            "pendingRewards amount not equal to transfer amount"
+        );
     }
 
     function test_rewardsClaiming() public {
@@ -276,5 +368,18 @@ contract MainnetForkTest is AngstromTest {
         }
 
         return pk;
+    }
+
+    function setAngstromLastBlockUpdated(uint64 blockNumber) public {
+        uint256 LAST_BLOCK_CONFIG_STORE_SLOT = 3;
+        uint256 LAST_BLOCK_BIT_OFFSET = 0;
+        uint256 STORE_BIT_OFFSET = 64;
+        address configStore = PoolConfigStore.unwrap(angstrom.configStore());
+        uint256 slotData = (uint256(blockNumber) << LAST_BLOCK_BIT_OFFSET) | (uint256(uint160(configStore)) << STORE_BIT_OFFSET);
+        vm.store(address(angstrom), bytes32(LAST_BLOCK_CONFIG_STORE_SLOT), bytes32(uint256(slotData)));
+        uint64 lastBlockUpdated = angstrom.lastBlockUpdated();
+        assertEq(blockNumber, lastBlockUpdated, "lastBlockUpdated not updated as expected");
+        address configStoreAfter = PoolConfigStore.unwrap(angstrom.configStore());
+        assertEq(configStore, configStoreAfter, "configStore should not have changed");
     }
 }

--- a/contracts/test/fork/MainnetFork.t.sol
+++ b/contracts/test/fork/MainnetFork.t.sol
@@ -1,0 +1,512 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {BaseTest} from "test/_helpers/BaseTest.sol";
+import {PoolManager} from "v4-core/src/PoolManager.sol";
+import {TickMath} from "v4-core/src/libraries/TickMath.sol";
+import {PoolId, PoolIdLibrary} from "v4-core/src/types/PoolId.sol";
+import {Angstrom} from "src/Angstrom.sol";
+import {TopLevelAuth, MAX_UNLOCK_FEE_E6} from "src/modules/TopLevelAuth.sol";
+import {Bundle} from "test/_reference/Bundle.sol";
+import {Asset, AssetLib} from "test/_reference/Asset.sol";
+import {Pair, PairLib} from "test/_reference/Pair.sol";
+import {UserOrder, UserOrderLib} from "test/_reference/UserOrder.sol";
+import {PartialStandingOrder, ExactFlashOrder} from "test/_reference/OrderTypes.sol";
+import {PriceAB as Price10} from "src/types/Price.sol";
+import {MockERC20} from "super-sol/mocks/MockERC20.sol";
+import {AngstromView} from "src/periphery/AngstromView.sol";
+import {RouterActor, PoolKey} from "test/_mocks/RouterActor.sol";
+import {SafeTransferLib} from "solady/src/utils/SafeTransferLib.sol";
+
+import {IHooks} from "v4-core/src/interfaces/IHooks.sol";
+import {Hooks} from "v4-core/src/libraries/Hooks.sol";
+
+// to force compile
+import {IPositionDescriptor} from "v4-periphery/src/interfaces/IPositionDescriptor.sol";
+import {console} from "forge-std/console.sol";
+
+import {IUniV4} from "src/interfaces/IUniV4.sol";
+import {PoolUpdateLib, PoolUpdate, RewardsUpdate} from "test/_reference/PoolUpdate.sol";
+
+contract MainnetForkTest is BaseTest {
+    using AngstromView for Angstrom;
+    using SafeTransferLib for address;
+
+    using Hooks for IHooks;
+
+    using PairLib for Pair[];
+    using AssetLib for Asset[];
+
+    using IUniV4 for PoolManager;
+    using PoolUpdateLib for PoolUpdate;
+
+    PoolManager uni;
+    Angstrom angstrom;
+    bytes32 domainSeparator;
+
+    address controller;
+    Account node = makeAccount("node");
+    address asset0;
+    address asset1;
+
+    RouterActor actor;
+
+    function setUp() public {
+        // Create and select in one call
+        uint256 forkId = vm.createSelectFork("mainnet");
+        assertEq(vm.activeFork(), forkId);
+
+        uni = PoolManager(address(0x000000000004444c5dc75cB358380D2e3dE08A90));
+        angstrom = Angstrom(0x0000000aa232009084Bd71A5797d089AA4Edfad4);
+        domainSeparator = computeDomainSeparator(address(angstrom));
+        controller = angstrom.controller();
+
+        vm.prank(controller);
+        angstrom.toggleNodes(addressArray(abi.encode(node.addr)));
+
+        actor = new RouterActor(uni);
+
+        (asset0, asset1) = deployTokensSorted();
+        MockERC20(asset0).mint(address(uni), 100_000e18);
+        MockERC20(asset1).mint(address(uni), 100_000e18);
+
+        MockERC20(asset0).mint(address(actor), 100_000_000e18);
+        MockERC20(asset1).mint(address(actor), 100_000_000e18);
+
+        vm.roll(block.number + 1);
+    }
+
+    // get the WETH/USDC pool global rewards growth and check that it is nonzero
+    function test_getGlobalRewardsGrowth() public {
+        PoolId id = PoolId.wrap(
+            bytes32(0xe500210c7ea6bfd9f69dce044b09ef384ec2b34832f132baec3b418208e3a657)
+        );
+        uint256 poolRewardsGlobalGrowth = angstrom.poolRewardsGlobalGrowth({id: id});
+        emit log_named_uint("poolRewardsGlobalGrowth", poolRewardsGlobalGrowth);
+    }
+
+    function test_rewardsClaiming() public {
+        uint248 liq = 100_000e21;
+        uint248 startLiquidity = liq;
+        uint256 bundleFee = 0.002e6;
+        uint16 tickSpacing = 60;
+
+        vm.prank(controller);
+        angstrom.configurePool({
+            asset0: asset0,
+            asset1: asset1,
+            tickSpacing: tickSpacing,
+            bundleFee: uint24(bundleFee),
+            unlockedFee: 0,
+            protocolUnlockedFee: 0
+        });
+        angstrom.initializePool({
+            assetA: asset0,
+            assetB: asset1,
+            storeIndex: 2,
+            sqrtPriceX96: TickMath.getSqrtPriceAtTick(0)
+        });
+        int24 spacing = int24(uint24(tickSpacing));
+        PoolKey memory pk = poolKey(angstrom, asset0, asset1, spacing);
+        if (startLiquidity > 0) {
+            actor.modifyLiquidity(
+                pk, -1 * spacing, 1 * spacing, int256(uint256(startLiquidity)), bytes32(0)
+            );
+        }
+
+        console.log("asset0: %s", asset0);
+        console.log("asset1: %s", asset1);
+
+        Account memory user1 = makeAccount("user_1");
+        MockERC20(asset0).mint(user1.addr, 100.0e18);
+        vm.prank(user1.addr);
+        MockERC20(asset0).approve(address(angstrom), type(uint256).max);
+
+        Account memory user2 = makeAccount("user_2");
+        MockERC20(asset1).mint(user2.addr, 100.0e18);
+        vm.prank(user2.addr);
+        MockERC20(asset1).approve(address(angstrom), type(uint256).max);
+
+        Price10 price = Price10.wrap(1e27);
+
+        Bundle memory bundle;
+
+        bundle.addAsset(asset0).addAsset(asset1).addPair(asset0, asset1, price);
+        bundle.userOrders = new UserOrder[](2);
+
+        {
+            PartialStandingOrder memory order;
+            order.maxAmountIn = 20.0e18;
+            order.maxExtraFeeAsset0 = 1.3e18;
+            order.minPrice = 0.1e27;
+            order.assetIn = asset0;
+            order.assetOut = asset1;
+            order.deadline = u40(block.timestamp + 60 minutes);
+            sign(user1, order.meta, digest712(order.hash()));
+            order.extraFeeAsset0 = 1.0e18;
+            order.amountFilled = 10.0e18;
+            bundle.userOrders[0] = UserOrderLib.from(order);
+        }
+
+        {
+            ExactFlashOrder memory order;
+            order.exactIn = true;
+            order.amount = 9.200400801603206413e18;
+            order.maxExtraFeeAsset0 = 0.2e18;
+            order.minPrice = 0.1e27;
+            order.assetIn = asset1;
+            order.assetOut = asset0;
+            order.validForBlock = u64(block.number);
+            sign(user2, order.meta, digest712(order.hash()));
+            order.extraFeeAsset0 = 0.2e18;
+            bundle.userOrders[1] = UserOrderLib.from(order);
+        }
+
+        // MockERC20(asset0).mint(address(angstrom), 0.1e18);
+        // uint128 onlyCurrentQuantity = 0;
+        uint128[] memory quantities;
+        bundle.addPoolUpdate({
+            assetIn: asset0,
+            assetOut: asset1,
+            amountIn: 0,
+            onlyCurrent: true,
+            onlyCurrentQuantity: 1e18,
+            startTick: 0,
+            startLiquidity: 0,
+            quantities: quantities,
+            rewardChecksum: 0
+        });
+
+        bundle.assets[0].save += 1.018e18;
+        bundle.assets[1].save += 0.218400801603206413e18;
+        bundle.assets[0].take += 0;
+        bundle.assets[1].take += 10.0e18;
+        bundle.assets[1].settle += 10.0e18;
+
+        bundle.assets[0].save -= bundle.poolUpdates[0].rewardUpdate.onlyCurrentQuantity;
+        // bundle.assets[0].take += bundle.poolUpdates[0].amountIn;
+        uint256 existingLiquidity = uni.getPoolLiquidity(pk.toId());
+        emit log_named_uint("existingLiquidity", existingLiquidity);
+        // returns 100000000000000000000000000 (as expected)
+
+        emit log(bundle.poolUpdates[0].rewardUpdate.toStr());
+        // returns RewardsUpdate::CurrentOnly { amount: 1000000000000000000 } (as expected)
+
+        // manually write rewards slot
+        uint256 rewardsMapSlot =
+        // uint256(bytes32(keccak256(abi.encode(pk.toId(), POOL_REWARDS_SLOT)))) + REWARD_GROWTH_SIZE;
+         uint256(bytes32(keccak256(abi.encode(pk.toId(), 7)))) + 16777216;
+        vm.store(address(angstrom), bytes32(rewardsMapSlot), bytes32(uint256(1e30)));
+
+        bytes memory payload = bundle.encode(rawGetConfigStore(address(angstrom)));
+        vm.prank(node.addr);
+        angstrom.execute(payload);
+        // test_userOrderWithFees();
+
+        // int24 tickLower = -1 * int24(uint24(60));
+        // int24 tickUpper = 1 * int24(uint24(60));
+        uint256 poolRewardsGlobalGrowth = angstrom.poolRewardsGlobalGrowth({id: pk.toId()});
+        emit log_named_uint("poolRewardsGlobalGrowth", poolRewardsGlobalGrowth);
+        assertGt(poolRewardsGlobalGrowth, 0, "poolRewardsGlobalGrowth should be nonzero");
+        {
+            uint256 lastGrowthInside = angstrom.getLastGrowthInside({
+                id: pk.toId(),
+                uniPositionKey: keccak256(
+                    abi.encodePacked(
+                        address(actor), -1 * int24(uint24(60)), 1 * int24(uint24(60)), bytes32(0)
+                    )
+                )
+            });
+            emit log_named_uint("lastGrowthInside", lastGrowthInside);
+        }
+
+        // PoolKey memory pk = poolKey(angstrom, asset0, asset1, 60);
+        uint256 pendingRewards = angstrom.pendingRewards({
+            account: address(actor),
+            key: pk,
+            tickLower: -1 * int24(uint24(60)),
+            tickUpper: 1 * int24(uint24(60)),
+            salt: bytes32(0),
+            uniV4: uni
+        });
+        assertGt(pendingRewards, 0, "pendingRewards should be nonzero");
+        uint256 asset0BalanceBefore = MockERC20(asset0).balanceOf(address(actor));
+        emit log_named_uint("pendingRewards", pendingRewards);
+
+        actor.modifyLiquidity(
+            pk, -1 * int24(uint24(60)), 1 * int24(uint24(60)), int256(uint256(0)), bytes32(0)
+        );
+
+        {
+            uint256 asset0BalanceAfter = MockERC20(asset0).balanceOf(address(actor));
+            assertEq(
+                asset0BalanceAfter, asset0BalanceBefore + pendingRewards, "pendingRewards incorrect"
+            );
+        }
+
+        pendingRewards = angstrom.pendingRewards({
+            account: address(actor),
+            key: pk,
+            tickLower: -1 * int24(uint24(60)),
+            tickUpper: 1 * int24(uint24(60)),
+            salt: bytes32(0),
+            uniV4: uni
+        });
+        assertEq(pendingRewards, 0, "pendingRewards should be zero");
+    }
+
+    function test_userOrderWithFees() public {
+        uint256 fee = 0.002e6;
+
+        vm.prank(controller);
+        angstrom.configurePool(asset0, asset1, 1, uint24(fee), 0, 0);
+
+        console.log("asset0: %s", asset0);
+        console.log("asset1: %s", asset1);
+
+        Account memory user1 = makeAccount("user_1");
+        MockERC20(asset0).mint(user1.addr, 100.0e18);
+        vm.prank(user1.addr);
+        MockERC20(asset0).approve(address(angstrom), type(uint256).max);
+
+        Account memory user2 = makeAccount("user_2");
+        MockERC20(asset1).mint(user2.addr, 100.0e18);
+        vm.prank(user2.addr);
+        MockERC20(asset1).approve(address(angstrom), type(uint256).max);
+
+        Price10 price = Price10.wrap(1e27);
+
+        Bundle memory bundle;
+
+        bundle.addAsset(asset0).addAsset(asset1).addPair(asset0, asset1, price);
+        bundle.userOrders = new UserOrder[](2);
+
+        {
+            PartialStandingOrder memory order;
+            order.maxAmountIn = 20.0e18;
+            order.maxExtraFeeAsset0 = 1.3e18;
+            order.minPrice = 0.1e27;
+            order.assetIn = asset0;
+            order.assetOut = asset1;
+            order.deadline = u40(block.timestamp + 60 minutes);
+            sign(user1, order.meta, digest712(order.hash()));
+            order.extraFeeAsset0 = 1.0e18;
+            order.amountFilled = 10.0e18;
+            bundle.userOrders[0] = UserOrderLib.from(order);
+        }
+
+        {
+            ExactFlashOrder memory order;
+            order.exactIn = true;
+            order.amount = 9.200400801603206413e18;
+            order.maxExtraFeeAsset0 = 0.2e18;
+            order.minPrice = 0.1e27;
+            order.assetIn = asset1;
+            order.assetOut = asset0;
+            order.validForBlock = u64(block.number);
+            sign(user2, order.meta, digest712(order.hash()));
+            order.extraFeeAsset0 = 0.2e18;
+            bundle.userOrders[1] = UserOrderLib.from(order);
+        }
+
+        bundle.assets[0].save += 1.018e18;
+        bundle.assets[1].save += 0.218400801603206413e18;
+        bundle.assets[1].take += 10.0e18;
+        bundle.assets[1].settle += 10.0e18;
+
+        bytes memory payload = bundle.encode(rawGetConfigStore(address(angstrom)));
+        vm.prank(node.addr);
+        angstrom.execute(payload);
+    }
+
+    function test_fuzzing_swapWithUnlockData(
+        uint256 bnInput,
+        uint24 unlockedFee,
+        uint256 swapAmount1,
+        uint256 swapAmount2
+    ) public {
+        uint64 bn = bound_block(bnInput);
+        vm.roll(bn);
+
+        bytes32 digest = erc712Hash(
+            computeDomainSeparator(address(angstrom)),
+            keccak256(abi.encode(keccak256("AttestAngstromBlockEmpty(uint64 block_number)"), bn))
+        );
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(node.key, digest);
+
+        bytes memory unlockData = bytes.concat(bytes20(node.addr), r, s, bytes1(v));
+
+        unlockedFee = uint24(bound(unlockedFee, 0, MAX_UNLOCK_FEE_E6));
+        swapAmount1 = bound(swapAmount1, 1e8, 10e18);
+        swapAmount2 = bound(swapAmount2, 1e8, 10e18);
+
+        PoolKey memory pk = _createPool({
+            tickSpacing: 60,
+            unlockedFee: unlockedFee,
+            startLiquidity: 100_000e21,
+            protocolUnlockedFee: 0
+        });
+
+        uint256 pendingRewards = angstrom.pendingRewards({
+            account: address(actor),
+            key: pk,
+            tickLower: -1 * int24(uint24(60)),
+            tickUpper: 1 * int24(uint24(60)),
+            salt: bytes32(0),
+            uniV4: uni
+        });
+        assertEq(pendingRewards, 0, "pendingRewards should be zero before swaps");
+
+        vm.prank(node.addr);
+        angstrom.execute("");
+        int128 withFeeOut =
+            actor.swap(pk, true, -int256(swapAmount1), 4295128740, unlockData).amount1();
+
+        assertGe(withFeeOut, 0);
+        assertEq(angstrom.lastBlockUpdated(), bn);
+
+        withFeeOut = actor.swap(pk, true, -int256(swapAmount2), 4295128740, unlockData).amount1();
+        assertGe(withFeeOut, 0);
+
+        pendingRewards = angstrom.pendingRewards({
+            account: address(actor),
+            key: pk,
+            tickLower: -1 * int24(uint24(60)),
+            tickUpper: 1 * int24(uint24(60)),
+            salt: bytes32(0),
+            uniV4: uni
+        });
+        assertGt(pendingRewards, 0, "pendingRewards should be nonzero after swaps");
+    }
+
+    function test_claimRewards() public {
+        test_fuzzing_unlockSwapWithProtocolFee({
+            bnInput: 2 ** 32,
+            unlockedFee: 0.1e6,
+            swapAmount1: 1e18,
+            swapAmount2: 3e18,
+            protocol_unlock_swap_fee_e6: 0.01e6
+        });
+
+        PoolKey memory pk = poolKey(angstrom, asset0, asset1, 60);
+        uint256 pendingRewards = angstrom.pendingRewards({
+            account: address(actor),
+            key: pk,
+            tickLower: -1 * int24(uint24(60)),
+            tickUpper: 1 * int24(uint24(60)),
+            salt: bytes32(0),
+            uniV4: uni
+        });
+        assertGt(pendingRewards, 0, "pendingRewards should be nonzero");
+        uint256 asset0BalanceBefore = MockERC20(asset0).balanceOf(address(this));
+        emit log_named_uint("pendingRewards", pendingRewards);
+
+        actor.modifyLiquidity(
+            pk, -1 * int24(uint24(60)), 1 * int24(uint24(60)), int256(uint256(0)), bytes32(0)
+        );
+
+        uint256 asset0BalanceAfter = MockERC20(asset0).balanceOf(address(this));
+        assertEq(
+            asset0BalanceAfter, asset0BalanceBefore + pendingRewards, "pendingRewards incorrect"
+        );
+
+        pendingRewards = angstrom.pendingRewards({
+            account: address(actor),
+            key: pk,
+            tickLower: -1 * int24(uint24(60)),
+            tickUpper: 1 * int24(uint24(60)),
+            salt: bytes32(0),
+            uniV4: uni
+        });
+        assertEq(pendingRewards, 0, "pendingRewards should be zero");
+    }
+
+    function test_fuzzing_unlockSwapWithProtocolFee(
+        uint256 bnInput,
+        uint24 unlockedFee,
+        uint256 swapAmount1,
+        uint256 swapAmount2,
+        uint24 protocol_unlock_swap_fee_e6
+    ) public {
+        uint64 bn = bound_block(bnInput);
+        vm.roll(bn);
+
+        unlockedFee = uint24(bound(unlockedFee, 0, MAX_UNLOCK_FEE_E6));
+        protocol_unlock_swap_fee_e6 = uint24(bound(protocol_unlock_swap_fee_e6, 0, 0.02e6));
+        swapAmount1 = bound(swapAmount1, 1e8, 10e18);
+        swapAmount2 = bound(swapAmount2, 1e8, 10e18);
+
+        uint248 liq = 100_000e21;
+
+        PoolKey memory pk = _createPool(60, unlockedFee, liq, protocol_unlock_swap_fee_e6);
+
+        vm.prank(node.addr);
+        angstrom.execute("");
+        int128 withFeeOut1 = actor.swap(pk, true, -int256(swapAmount1), 4295128740, "").amount1();
+
+        assertGe(withFeeOut1, 0);
+        assertEq(angstrom.lastBlockUpdated(), bn);
+
+        int128 withFeeOut2 = actor.swap(pk, true, -int256(swapAmount2), 4295128740, "").amount1();
+        assertGe(withFeeOut2, 0);
+
+        address fee_recv = makeAddr("temp_fee_recv");
+        vm.prank(controller);
+        angstrom.collect_unlock_swap_fees(fee_recv, abi.encodePacked(asset1));
+
+        uint256 fee_collected = asset1.balanceOf(fee_recv);
+
+        console.log("here");
+
+        uint256 effective_fee_share =
+            (fee_collected * 1e18) / (uint128(withFeeOut1) + uint128(withFeeOut2) + fee_collected);
+
+        console.log("here? (%s)", protocol_unlock_swap_fee_e6);
+
+        assertApproxEqRel(effective_fee_share, uint256(protocol_unlock_swap_fee_e6) * 1e12, 0.01e18);
+    }
+
+    function _createPool(
+        uint16 tickSpacing,
+        uint24 unlockedFee,
+        uint248 startLiquidity,
+        uint24 protocolUnlockedFee
+    ) internal returns (PoolKey memory pk) {
+        vm.prank(controller);
+        angstrom.configurePool({
+            asset0: asset0,
+            asset1: asset1,
+            tickSpacing: tickSpacing,
+            bundleFee: 0,
+            unlockedFee: unlockedFee,
+            protocolUnlockedFee: protocolUnlockedFee
+        });
+        angstrom.initializePool({
+            assetA: asset0,
+            assetB: asset1,
+            storeIndex: 2,
+            sqrtPriceX96: TickMath.getSqrtPriceAtTick(0)
+        });
+        int24 spacing = int24(uint24(tickSpacing));
+        pk = poolKey(angstrom, asset0, asset1, spacing);
+        if (startLiquidity > 0) {
+            actor.modifyLiquidity(
+                pk, -1 * spacing, 1 * spacing, int256(uint256(startLiquidity)), bytes32(0)
+            );
+        }
+
+        return pk;
+    }
+
+    function bound_block(uint256 bn) internal pure returns (uint64) {
+        return bound_block(bn, type(uint64).max);
+    }
+
+    function bound_block(uint256 bn, uint64 upper) internal pure returns (uint64) {
+        return uint64(bound(bn, 1, upper));
+    }
+
+    function digest712(bytes32 structHash) internal view returns (bytes32) {
+        return erc712Hash(domainSeparator, structHash);
+    }
+}


### PR DESCRIPTION
- Add more functions to `AngstromView` library, particularly for aiding in queries of LP positions and their rewards
- Implement fork testing against ETH mainnet, including validation of the new library functions
- Create a wrapper contract `AngstromInspector` which exposes library functions, so that users can simply call this contract's functions for queries
- Add simple deploy script for the `AngstromInspector` contract