### PR TITLE
feat: add event emitter

### DIFF
--- a/contracts/script/EventEmitter.s.sol
+++ b/contracts/script/EventEmitter.s.sol
@@ -9,8 +9,13 @@ contract EventEmitterScript is Script {
     function run() public {
         vm.startBroadcast();
         address timelock = timelockOnCurrentChain();
+        address multisig = multisigOnCurrentChain();
 
-        EventEmitter emitter = new EventEmitter(timelock);
+        address[] memory initialAdmins = new address[](2);
+        initialAdmins[0] = timelock;
+        initialAdmins[1] = multisig;
+
+        EventEmitter emitter = new EventEmitter(initialAdmins);
         console.log("[INFO] deployed event emitter to %s", address(emitter));
     }
 
@@ -21,6 +26,13 @@ contract EventEmitterScript is Script {
     function timelockOnCurrentChain() internal returns (address) {
         if (isChain("mainnet")) {
             return 0x60D41d9708BBEfd29000d1486C6406Ef23526c01;
+        }
+        revert(string.concat("Unsupported chain: ", getChain(block.chainid).name));
+    }
+
+    function multisigOnCurrentChain() internal returns (address) {
+        if (isChain("mainnet")) {
+            return 0xD31C82069da3013fdB16B731AD19076Af9b93105;
         }
         revert(string.concat("Unsupported chain: ", getChain(block.chainid).name));
     }

--- a/contracts/script/EventEmitter.s.sol
+++ b/contracts/script/EventEmitter.s.sol
@@ -7,7 +7,6 @@ import {EventEmitter} from "src/periphery/EventEmitter.sol";
 
 contract EventEmitterScript is Script {
     function run() public {
-        vm.startBroadcast();
         address timelock = timelockOnCurrentChain();
         address multisig = multisigOnCurrentChain();
 
@@ -15,7 +14,10 @@ contract EventEmitterScript is Script {
         initialAdmins[0] = timelock;
         initialAdmins[1] = multisig;
 
+        vm.startBroadcast();
         EventEmitter emitter = new EventEmitter(initialAdmins);
+        vm.stopBroadcast();
+
         console.log("[INFO] deployed event emitter to %s", address(emitter));
     }
 

--- a/contracts/script/EventEmitter.s.sol
+++ b/contracts/script/EventEmitter.s.sol
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {Script} from "forge-std/Script.sol";
+import {console} from "forge-std/console.sol";
+import {EventEmitter} from "src/periphery/EventEmitter.sol";
+
+contract EventEmitterScript is Script {
+    function run() public {
+        vm.startBroadcast();
+        address timelock = timelockOnCurrentChain();
+
+        EventEmitter emitter = new EventEmitter(timelock);
+        console.log("[INFO] deployed event emitter to %s", address(emitter));
+    }
+
+    function isChain(string memory name) internal returns (bool) {
+        return getChain(name).chainId == block.chainid;
+    }
+
+    function timelockOnCurrentChain() internal returns (address) {
+        if (isChain("mainnet")) {
+            return 0x60D41d9708BBEfd29000d1486C6406Ef23526c01;
+        }
+        revert(string.concat("Unsupported chain: ", getChain(block.chainid).name));
+    }
+}

--- a/contracts/src/periphery/EventEmitter.sol
+++ b/contracts/src/periphery/EventEmitter.sol
@@ -30,6 +30,10 @@ contract EventEmitter is Ownable {
     error InputLengthMismatch();
     error TopicsExceedMax();
 
+    constructor(address initialOwner) {
+        _initializeOwner(initialOwner);
+    }
+
     function emitFeeClaimQueued(
         address[] calldata assets,
         uint256[] calldata amounts,

--- a/contracts/src/periphery/EventEmitter.sol
+++ b/contracts/src/periphery/EventEmitter.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-import {Ownable} from "solady/src/auth/Ownable.sol";
+import {AccessControlEnumerable} from "lib/openzeppelin-contracts/contracts/access/extensions/AccessControlEnumerable.sol";
 
-/// @notice Simple contract which allows the contract owner to emit events.
-contract EventEmitter is Ownable {
+/// @notice Simple contract which allows the contract `DEFAULT_ADMIN_ROLE` to emit events.
+contract EventEmitter is AccessControlEnumerable {
     enum FeeClaimType {
         GAS,
         PROTOCOL,
@@ -29,9 +29,15 @@ contract EventEmitter is Ownable {
 
     error InputLengthMismatch();
     error TopicsExceedMax();
+    error ZeroAdminsAtConstruction();
 
-    constructor(address initialOwner) {
-        _initializeOwner(initialOwner);
+    constructor(address[] memory initialAdmins) {
+        if (initialAdmins.length == 0) {
+            revert ZeroAdminsAtConstruction();
+        }
+        for (uint256 i = 0; i < initialAdmins.length; ++i) {
+            _grantRole(DEFAULT_ADMIN_ROLE, initialAdmins[i]);
+        }
     }
 
     function emitFeeClaimQueued(
@@ -40,7 +46,7 @@ contract EventEmitter is Ownable {
         FeeClaimType claimType,
         uint256 startBlock,
         uint256 endBlock
-    ) external onlyOwner {
+    ) external onlyRole(DEFAULT_ADMIN_ROLE) {
         if (assets.length != amounts.length) {
             revert InputLengthMismatch();
         }
@@ -55,7 +61,7 @@ contract EventEmitter is Ownable {
         FeeClaimType claimType,
         uint256 startBlock,
         uint256 endBlock
-    ) external onlyOwner {
+    ) external onlyRole(DEFAULT_ADMIN_ROLE) {
         if (assets.length != amounts.length) {
             revert InputLengthMismatch();
         }
@@ -69,7 +75,7 @@ contract EventEmitter is Ownable {
     /// @param logData defines the unindexed data of the log.
     function emitGenericEvent(bytes32[] calldata topics, bytes calldata logData)
         external
-        onlyOwner
+        onlyRole(DEFAULT_ADMIN_ROLE)
     {
         if (topics.length > 4) {
             revert TopicsExceedMax();

--- a/contracts/src/periphery/EventEmitter.sol
+++ b/contracts/src/periphery/EventEmitter.sol
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {Ownable} from "solady/src/auth/Ownable.sol";
+
+/// @notice Simple contract which allows the contract owner to emit events.
+contract EventEmitter is Ownable {
+    enum FeeClaimType {
+        GAS,
+        PROTOCOL,
+        BOTH
+    }
+
+    event FeeClaimQueued(
+        address indexed asset,
+        FeeClaimType indexed claimType,
+        uint256 amount,
+        uint256 startBlock,
+        uint256 endBlock
+    );
+
+    event FeeClaimExecuted(
+        address indexed asset,
+        FeeClaimType indexed claimType,
+        uint256 amount,
+        uint256 startBlock,
+        uint256 endBlock
+    );
+
+    error InputLengthMismatch();
+    error TopicsExceedMax();
+
+    function emitFeeClaimQueued(
+        address[] calldata assets,
+        uint256[] calldata amounts,
+        FeeClaimType claimType,
+        uint256 startBlock,
+        uint256 endBlock
+    ) external onlyOwner {
+        if (assets.length != amounts.length) {
+            revert InputLengthMismatch();
+        }
+        for (uint256 i = 0; i < assets.length; ++i) {
+            emit FeeClaimQueued(assets[i], claimType, amounts[i], startBlock, endBlock);
+        }
+    }
+
+    function emitFeeClaimExecuted(
+        address[] calldata assets,
+        uint256[] calldata amounts,
+        FeeClaimType claimType,
+        uint256 startBlock,
+        uint256 endBlock
+    ) external onlyOwner {
+        if (assets.length != amounts.length) {
+            revert InputLengthMismatch();
+        }
+        for (uint256 i = 0; i < assets.length; ++i) {
+            emit FeeClaimExecuted(assets[i], claimType, amounts[i], startBlock, endBlock);
+        }
+    }
+
+    /// @notice Emits an event defined entirely by the calldata.
+    /// @param topics defines the indexed topics and can have from 0 to 4 fields.
+    /// @param logData defines the unindexed data of the log.
+    function emitGenericEvent(bytes32[] calldata topics, bytes calldata logData)
+        external
+        onlyOwner
+    {
+        if (topics.length > 4) {
+            revert TopicsExceedMax();
+        }
+        assembly {
+            // Allocate memory for the logData
+            let dataPtr := mload(0x40)
+            let logDataLength := logData.length
+            calldatacopy(dataPtr, logData.offset, logDataLength)
+
+            // Update the free memory pointer
+            mstore(0x40, add(dataPtr, logDataLength))
+
+            let topicsLength := topics.length
+            switch topicsLength
+            case 0 {
+                log0(dataPtr, logDataLength)
+            }
+            case 1 {
+                log1(dataPtr, logDataLength, calldataload(topics.offset))
+            }
+            case 2 {
+                log2(
+                    dataPtr,
+                    logDataLength,
+                    calldataload(topics.offset),
+                    calldataload(add(topics.offset, 32))
+                )
+            }
+            case 3 {
+                log3(
+                    dataPtr,
+                    logDataLength,
+                    calldataload(topics.offset),
+                    calldataload(add(topics.offset, 32)),
+                    calldataload(add(topics.offset, 64))
+                )
+            }
+            case 4 {
+                log4(
+                    dataPtr,
+                    logDataLength,
+                    calldataload(topics.offset),
+                    calldataload(add(topics.offset, 32)),
+                    calldataload(add(topics.offset, 64)),
+                    calldataload(add(topics.offset, 96))
+                )
+            }
+        }
+    }
+}


### PR DESCRIPTION
Adds an exceedingly simple periphery contract which allows the owner to call it in order to emit events.

Currently this contract implements 3 methods: `emitFeeClaimQueued`, `emitFeeClaimExecuted`, and `emitGenericEvent`.

We had previously discussed only the _2nd_ one of these; the others are included for completeness and future flexibility -- using `emitFeeClaimQueued` when queuing a fee claim could help with observability (it perhaps can help an observer decode and understand what is being queued), and `emitGenericEvent` provides the ability to add new events in the future without needing to migrate to a different contract (although because the contract code will not contain the event definition, the events may be challenging to decode / the topic0 will not be automatically processed e.g. by Etherscan).

Let me know if we are confident we will *not* use `emitFeeClaimQueued` and/or `emitGenericEvent` and I will remove them.

Otherwise, I could see potentially wanting the `FeeClaimQueued`/`FeeClaimExecuted` events to have their data styled a bit closer to what will be used for the actual fee claim call -- let me know if there are any changes desired here.