### PR TITLE
fix(contracts): use Solady mulDiv in RayMathLib mulRayDown and divRayDown to prevent intermediate overflow

### DIFF
--- a/contracts/src/libraries/RayMathLib.sol
+++ b/contracts/src/libraries/RayMathLib.sol
@@ -13,7 +13,7 @@ library RayMathLib {
     uint256 internal constant RAY_2 = 1e54;
 
     function mulRayDown(uint256 x, uint256 y) internal pure returns (uint256) {
-        return x * y / RAY;
+        return x.mulDiv(y, RAY);
     }
 
     function mulRayUp(uint256 x, uint256 y) internal pure returns (uint256) {
@@ -21,7 +21,7 @@ library RayMathLib {
     }
 
     function divRayDown(uint256 x, uint256 y) internal pure returns (uint256) {
-        return x * RAY / y;
+        return x.mulDiv(RAY, y);
     }
 
     function divRayUp(uint256 x, uint256 y) internal pure returns (uint256) {


### PR DESCRIPTION
Updated mulRayDown and divRayDown in RayMathLib to use FixedPointMathLib.mulDiv. Previously, plain multiplication x * y / RAY and x * RAY / y could cause intermediate uint256 overflow for large token balances before division. Using mulDiv provides 512-bit intermediate precision, aligning with mulRayUp and divRayUp.
